### PR TITLE
docs: add READMEs for root, core, vscode packages and CONTRIBUTING guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,192 @@
+# Contributing to PromptRev
+
+Thanks for your interest in contributing. This document covers how the repo is structured, how to get set up locally, and the conventions we follow.
+
+## Prerequisites
+
+| Tool | Version | Why |
+|---|---|---|
+| Node.js | ≥ 18 | Runtime for all packages |
+| pnpm | ≥ 9 | Monorepo package manager |
+| VS Code | ≥ 1.85.0 | Extension development and testing |
+| Git | any | Version control |
+
+Install pnpm if you don't have it:
+
+```bash
+npm install -g pnpm
+```
+
+## Local setup
+
+```bash
+# Clone the repo
+git clone https://github.com/SirArnoldB/promptrev.git
+cd promptrev
+
+# Install all workspace dependencies in one command
+pnpm install
+```
+
+## Build order
+
+The packages have a dependency chain. Always build in this order:
+
+```
+core  →  vscode  →  cli
+```
+
+`vscode` and `cli` both depend on `@promptrev/core`. If `core` isn't built first, their TypeScript compilation will fail.
+
+```bash
+# Build everything in the right order
+pnpm build:core
+pnpm --filter @promptrev/vscode build
+pnpm --filter promptrev build          # once cli package exists
+```
+
+Or build everything at once (root script respects order):
+
+```bash
+pnpm build
+```
+
+## Development workflow
+
+### Working on `core`
+
+```bash
+pnpm --filter @promptrev/core watch    # rebuild on file change
+pnpm --filter @promptrev/core test     # run unit tests
+pnpm --filter @promptrev/core typecheck
+```
+
+### Working on the VS Code extension
+
+```bash
+# Keep core in watch mode in one terminal
+pnpm --filter @promptrev/core watch
+
+# Build the extension in another terminal
+pnpm --filter @promptrev/vscode watch
+
+# Then press F5 in VS Code to launch an Extension Development Host
+```
+
+The Extension Development Host opens a new VS Code window with the extension loaded. Changes to the extension require rebuilding and re-launching (Ctrl+R in the dev host window).
+
+### Working on the CLI
+
+```bash
+pnpm --filter promptrev watch
+```
+
+## Running tests
+
+```bash
+# All packages
+pnpm test
+
+# Core only
+pnpm --filter @promptrev/core test
+
+# Watch mode
+pnpm --filter @promptrev/core test:watch
+```
+
+## Package structure overview
+
+```mermaid
+graph TD
+    ROOT["monorepo root<br/>package.json, tsconfig.base.json"]
+    CORE["packages/core<br/>@promptrev/core"]
+    VSCODE["packages/vscode<br/>@promptrev/vscode"]
+    CLI["packages/cli<br/>promptrev"]
+    GH[".github/workflows/ci.yml"]
+
+    ROOT --> CORE
+    ROOT --> VSCODE
+    ROOT --> CLI
+    CORE --> VSCODE
+    CORE --> CLI
+    GH -.->|validates| ROOT
+```
+
+### `packages/core`
+
+The enhancement engine. Pure TypeScript — no VS Code API, no filesystem, no HTTP. Contains:
+- `enhancer.ts` — `enhance()` orchestrator
+- `modifiers.ts` — 7 built-in modifier definitions + `resolveModifier()`
+- `model-adapter.ts` — `ModelAdapter` interface + `RuleBasedAdapter`
+- `diff.ts` — word-level diff utilities
+- `history.ts` — `HistoryManager` with pluggable storage
+- `rule-based.ts` — `:fast` mode, deterministic text cleanup
+
+### `packages/vscode`
+
+The VS Code extension. Registers the `@rev` chat participant, the `Cmd+Shift+E` keybinding command, and the history sidebar panel. Implements `VSCodeModelAdapter` using `vscode.lm`. Depends on `@promptrev/core`.
+
+### `packages/cli` _(coming soon)_
+
+The npm CLI and SDK package. Implements `AnthropicModelAdapter` using the Anthropic SDK. Depends on `@promptrev/core`.
+
+## Branching and PR conventions
+
+### Branch naming
+
+```
+feat/<short-description>      # new feature
+fix/<short-description>       # bug fix
+docs/<short-description>      # documentation only
+infra/<short-description>     # CI, build, tooling
+refactor/<short-description>  # no behaviour change
+```
+
+### Commit messages
+
+We use conventional commit style:
+
+```
+feat: add :spec modifier system prompt
+fix: handle AbortError propagation in enhance()
+docs: add core package API reference
+infra: add Node 20 to CI matrix
+```
+
+### Pull requests
+
+- **One concern per PR** — keep PRs small and focused
+- **Tag the issue** — every PR should close at least one issue with `Closes #N`
+- **Tests required** — new behaviour in `core` needs unit tests
+- **No broken builds** — CI must pass before merge (build + typecheck + tests)
+
+## CI pipeline
+
+Every push to `main` and every PR runs:
+
+```
+install dependencies
+    ↓
+build @promptrev/core
+    ↓
+typecheck @promptrev/vscode
+    ↓
+build @promptrev/vscode
+    ↓
+test @promptrev/core
+    ↓
+VSIX package dry-run
+```
+
+Runs on Node 18 and Node 20. See [`.github/workflows/ci.yml`](.github/workflows/ci.yml).
+
+## Adding a new modifier
+
+1. Add the modifier definition to `packages/core/src/modifiers.ts` in `BUILT_IN_MODIFIERS`
+2. Add the modifier as a command in `packages/vscode/package.json` under `contributes.chatParticipants[0].commands`
+3. Add a test case in `packages/core/src/__tests__/modifiers.test.ts`
+4. Update the modifier table in `packages/vscode/README.md` and the root `README.md`
+
+## Questions?
+
+Open an issue or start a discussion on GitHub.

--- a/README.md
+++ b/README.md
@@ -2,68 +2,138 @@
 
 > Instantly enhance your AI prompts with `@rev` — VS Code extension, CLI, and SDK.
 
-PromptRev is a developer tool that automatically enhances, polishes, and refines prompts before they are sent to an AI agent. It works as a VS Code extension, a CLI npm package, and a standalone SDK.
+PromptRev is a developer tool that automatically enhances, polishes, and refines prompts before they are sent to an AI agent. It works as a VS Code extension, a CLI npm package, and a standalone SDK — meeting developers wherever they work.
+
+## How it works
+
+```mermaid
+graph TD
+    U([Developer]) -->|types prompt| VS["VS Code<br/>@rev chat / Cmd+Shift+E"]
+    U -->|types prompt| CLI["CLI<br/>rev 'your prompt'"]
+
+    VS -->|uses| CORE["@promptrev/core<br/>Enhancement Engine"]
+    CLI -->|uses| CORE
+
+    CORE -->|LLM path| LM["vscode.lm / Anthropic API"]
+    CORE -->|:fast path| RB["Rule-based<br/>(zero latency)"]
+
+    LM --> OUT([Enhanced prompt])
+    RB --> OUT
+```
+
+## Package architecture
+
+```mermaid
+graph LR
+    CORE["@promptrev/core<br/><i>shared engine</i>"]
+    VSCODE["@promptrev/vscode<br/><i>VS Code extension</i>"]
+    CLI["promptrev<br/><i>CLI + SDK</i>"]
+
+    VSCODE -->|workspace:*| CORE
+    CLI -->|workspace:*| CORE
+```
+
+`core` has zero platform dependencies — no VS Code, no Node I/O. Both `vscode` and `cli` adapt it to their environment through the `ModelAdapter` interface.
 
 ## Features
 
 - **`@rev` Chat Participant** — type `@rev your prompt` in VS Code Chat for instant enhancement
-- **Global keybinding** — `Cmd+Shift+E` / `Ctrl+Shift+E` to enhance selected text
-- **Modifier system** — `:fast`, `:deep`, `:architect`, `:critic`, `:spell`, `:spec`
+- **Global keybinding** — `Cmd+Shift+E` / `Ctrl+Shift+E` to enhance selected text in any editor
+- **Modifier system** — `:fast`, `:deep`, `:architect`, `:critic`, `:spell`, `:spec`, and custom
 - **No extra API key needed** — reuses your existing Copilot/Claude model via `vscode.lm`
 - **Prompt history panel** — review, restore, and export past enhancements
+- **CLI + SDK** — use from the terminal or integrate into your own tools
 
-## Monorepo Structure
+## Modifier quick reference
+
+| Modifier | Best for | Auto-send | Latency |
+|---|---|---|---|
+| `@rev` (default) | Everyday prompts | Off | ~400ms |
+| `@rev:fast` | High-velocity flow | On | ~0ms (rule-based) |
+| `@rev:deep` | Architecture, complex tasks | Off | ~700ms |
+| `@rev:architect` | System design, trade-offs | Off | ~600ms |
+| `@rev:critic` | Code review, security audits | Off | ~500ms |
+| `@rev:spell` | Grammar/spelling only | Off | ~300ms |
+| `@rev:spec` | Idea → acceptance criteria | Off | ~600ms |
+
+## Monorepo structure
 
 ```
 promptrev/
 ├── packages/
-│   ├── core/     ← Shared enhancement engine (@promptrev/core)
-│   ├── vscode/   ← VS Code/Visual Studio extension
-│   └── cli/      ← npm SDK + CLI binary (promptrev)
-├── docs/         ← PRD, technical spec, design decisions
+│   ├── core/        ← @promptrev/core  — shared enhancement engine
+│   ├── vscode/      ← @promptrev/vscode — VS Code extension
+│   └── cli/         ← promptrev        — CLI tool and SDK (coming soon)
+├── docs/            ← PRD, technical spec, design decisions
+├── .github/
+│   └── workflows/
+│       └── ci.yml   ← GitHub Actions CI
 └── ...
 ```
 
-## Getting Started
+## Getting started (development)
 
 ```bash
-# Install dependencies
+# Prerequisites: Node ≥18, pnpm ≥9
+npm install -g pnpm
+
+# Install all workspace dependencies
 pnpm install
 
-# Build core package
+# Build in dependency order
 pnpm build:core
+pnpm --filter @promptrev/vscode build
 
 # Run all tests
 pnpm test
+
+# Watch mode (core)
+pnpm --filter @promptrev/core watch
 ```
 
-## Usage (VS Code)
+## Usage — VS Code
+
+Install the extension, then in any VS Code Chat panel:
 
 ```
 @rev fix the bug in my auth module
-@rev:fast fix null check
-@rev:deep design a notification system
-@rev:architect design a job queue
-@rev:critic review my auth implementation
+@rev:fast fix null check on user.profile
+@rev:deep design a scalable notification system
+@rev:architect design a job queue with retry logic
+@rev:critic review my authentication implementation
 @rev:spell does this endpoint handel concurrent request proprly
-@rev:spec add user invite feature
+@rev:spec add user invite feature to the dashboard
 ```
 
-## Usage (CLI)
+Or select any text in the editor and press `Cmd+Shift+E` (`Ctrl+Shift+E` on Windows/Linux).
+
+## Usage — CLI
 
 ```bash
+# Enhance a prompt
 npx promptrev "fix the race condition in my queue worker"
+
+# With a modifier
 rev --mod deep "design a job queue system"
+
+# Pipe from stdin
 echo "fix null check" | rev --mod fast
+
+# JSON output
+rev --json "design a caching layer"
 ```
 
 ## Packages
 
-| Package | Description |
-|---|---|
-| `@promptrev/core` | Enhancement engine — no VS Code or Node I/O dependencies |
-| `@promptrev/vscode` | VS Code extension (published to Marketplace) |
-| `promptrev` | CLI tool and SDK (published to npm) |
+| Package | Description | Registry |
+|---|---|---|
+| [`@promptrev/core`](packages/core) | Enhancement engine — pure TypeScript, no platform deps | npm (internal) |
+| [`@promptrev/vscode`](packages/vscode) | VS Code / Visual Studio extension | VS Code Marketplace |
+| [`promptrev`](packages/cli) | CLI tool and SDK | npm |
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for dev setup, build order, and PR conventions.
 
 ## License
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,278 @@
+# @promptrev/core
+
+> The shared enhancement engine for PromptRev — pure TypeScript, no platform dependencies.
+
+This package contains all the business logic for prompt enhancement. It has no dependency on VS Code, the Node.js filesystem, or any specific LLM provider. Both the VS Code extension and CLI adapt it to their environment through the `ModelAdapter` interface.
+
+## How a prompt flows through core
+
+```mermaid
+sequenceDiagram
+    participant Caller as VS Code / CLI
+    participant E as enhance()
+    participant M as resolveModifier()
+    participant A as ModelAdapter
+    participant D as computeDiff()
+
+    Caller->>E: rawPrompt + modifier + modelAdapter
+    E->>M: modifier key + userModifiers
+    M-->>E: ModifierDefinition
+
+    alt useLLM = false (:fast)
+        E->>E: ruleBasedEnhance(rawPrompt)
+    else useLLM = true
+        E->>A: complete(systemPrompt, rawPrompt)
+        A-->>E: revised prompt
+    end
+
+    E->>D: computeDiff(original, revised)
+    D-->>E: DiffChunk[]
+    E-->>Caller: EnhancerOutput
+```
+
+## Modifier resolution
+
+```mermaid
+flowchart LR
+    K([modifier key]) --> BI{built-in?}
+    BI -->|yes + user override| MG[merged definition]
+    BI -->|yes, no override| BD[built-in definition]
+    BI -->|no| UD{user-defined?}
+    UD -->|yes| CD[custom definition]
+    UD -->|no| FB[default modifier fallback]
+```
+
+## Installation
+
+This package is internal to the PromptRev monorepo. It is referenced by `@promptrev/vscode` and `promptrev` (CLI) via `workspace:*`.
+
+If you want to use the enhancement engine in your own project:
+
+```bash
+npm install @promptrev/core
+```
+
+## API
+
+### `enhance(input)`
+
+The main entry point. Takes a raw prompt and returns an enhanced version.
+
+```typescript
+import { enhance, RuleBasedAdapter } from '@promptrev/core';
+
+const result = await enhance({
+  rawPrompt: 'fix the race condition in my queue worker',
+  modifier: 'deep',
+  domainContext: 'Node.js, Bull queue, Redis',
+  modelAdapter: new AnthropicModelAdapter({ apiKey: process.env.ANTHROPIC_API_KEY }),
+});
+
+console.log(result.revised);
+// → "Identify and fix the race condition in the queue worker.
+//    Focus on: concurrent job pickup, lock mechanisms, and
+//    ensuring idempotency. Explain the root cause and the fix."
+```
+
+**Input:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `rawPrompt` | `string` | Yes | The prompt to enhance |
+| `modifier` | `ModifierKey \| string` | Yes | Which modifier to apply |
+| `modelAdapter` | `ModelAdapter` | Yes | LLM or rule-based adapter |
+| `domainContext` | `string` | No | Tech stack hint injected into system prompt |
+| `userModifiers` | `Record<string, Partial<ModifierDefinition>>` | No | Custom or override modifier definitions |
+| `signal` | `AbortSignal` | No | Cancellation signal |
+
+**Output (`EnhancerOutput`):**
+
+| Field | Type | Description |
+|---|---|---|
+| `original` | `string` | The raw input prompt |
+| `revised` | `string` | The enhanced prompt |
+| `modifier` | `string` | Modifier key used |
+| `timestamp` | `number` | Unix ms timestamp |
+| `skipped` | `boolean` | `true` if prompt was too short or unchanged |
+| `diff` | `DiffChunk[]` | Word-level diff between original and revised |
+
+---
+
+### `resolveModifier(key, userModifiers?)`
+
+Resolves a modifier key to its full `ModifierDefinition`. User-defined overrides are merged on top of built-in defaults.
+
+```typescript
+import { resolveModifier } from '@promptrev/core';
+
+const mod = resolveModifier('deep');
+// → { key: 'deep', useLLM: true, acceptMode: 'diff', autoSend: false, ... }
+
+// With user override
+const mod2 = resolveModifier('deep', { deep: { autoSend: true } });
+// → { ...deepDefaults, autoSend: true }
+
+// Custom modifier
+const mod3 = resolveModifier('backend', {
+  backend: {
+    systemPrompt: 'Rewrite for a Node.js + PostgreSQL backend...',
+    acceptMode: 'diff',
+  },
+});
+```
+
+---
+
+### `ModelAdapter` interface
+
+The abstraction that decouples the enhancement engine from any specific LLM. Implement this interface to connect any model.
+
+```typescript
+export interface ModelAdapter {
+  complete(
+    systemPrompt: string,
+    userMessage: string,
+    signal?: AbortSignal
+  ): Promise<string>;
+}
+```
+
+**Provided adapters:**
+
+| Adapter | Location | Use case |
+|---|---|---|
+| `RuleBasedAdapter` | `@promptrev/core` | `:fast` mode, no LLM, zero latency |
+| `VSCodeModelAdapter` | `@promptrev/vscode` | VS Code extension via `vscode.lm` |
+| `AnthropicModelAdapter` | `promptrev` (CLI) | CLI via Anthropic SDK |
+
+**Example — custom adapter:**
+
+```typescript
+import type { ModelAdapter } from '@promptrev/core';
+
+class MyOpenAIAdapter implements ModelAdapter {
+  async complete(systemPrompt: string, userMessage: string): Promise<string> {
+    const res = await openai.chat.completions.create({
+      model: 'gpt-4o-mini',
+      messages: [
+        { role: 'system', content: systemPrompt },
+        { role: 'user', content: userMessage },
+      ],
+    });
+    return res.choices[0].message.content ?? '';
+  }
+}
+```
+
+---
+
+### Built-in modifiers
+
+| Key | `useLLM` | `acceptMode` | `autoSend` | Description |
+|---|---|---|---|---|
+| `default` | true | diff | false | Clarity, structure, context injection |
+| `fast` | false | auto | true | Rule-based only — zero latency |
+| `deep` | true | diff | false | Chain-of-thought, edge cases, structure |
+| `architect` | true | diff | false | System design, trade-offs, scalability |
+| `critic` | true | diff | false | Adversarial review, failure modes |
+| `spell` | true | diff | false | Grammar and spelling only |
+| `spec` | true | diff | false | Idea → structured spec + acceptance criteria |
+
+---
+
+### `HistoryManager`
+
+Manages a capped, ordered list of enhancement history entries with pluggable storage.
+
+```typescript
+import { HistoryManager, InMemoryStorage } from '@promptrev/core';
+
+const history = new HistoryManager(new InMemoryStorage(), 100);
+
+const entry = history.add({
+  original: 'fix the bug',
+  revised: 'Fix the null pointer bug in the auth module.',
+  modifier: 'default',
+  accepted: true,
+});
+
+history.getAll();       // newest-first
+history.restore(entry.id); // → 'fix the bug'
+history.export();       // → JSON string
+history.clear();
+```
+
+Implement `HistoryStorage` to plug in persistent storage (e.g. VS Code `globalState`):
+
+```typescript
+import type { HistoryStorage, HistoryEntry } from '@promptrev/core';
+
+class VSCodeStorage implements HistoryStorage {
+  constructor(private context: vscode.ExtensionContext) {}
+  get() { return this.context.globalState.get<HistoryEntry[]>('history', []); }
+  set(entries: HistoryEntry[]) { this.context.globalState.update('history', entries); }
+}
+```
+
+---
+
+### Diff utilities
+
+```typescript
+import { computeDiff, formatDiffMarkdown } from '@promptrev/core';
+
+const chunks = computeDiff('fix the bug', 'Fix the null pointer bug.');
+// → [{ type: 'delete', value: 'fix' }, { type: 'insert', value: 'Fix' }, ...]
+
+formatDiffMarkdown('fix the bug', 'Fix the null pointer bug.');
+// → "**Original:**\n> fix the bug\n\n**Revised:**\n> Fix the null pointer bug."
+```
+
+---
+
+### `ruleBasedEnhance(raw)`
+
+Applies deterministic text transformations — used by `:fast` mode.
+
+```typescript
+import { ruleBasedEnhance } from '@promptrev/core';
+
+ruleBasedEnhance('fix the recieve function idk');
+// → 'Fix the receive function.'
+```
+
+Rules applied in order:
+1. Fix common developer typos (`recieve` → `receive`, `databse` → `database`, etc.)
+2. Remove filler phrases (`idk`, `or something`, `maybe`, `kinda`, etc.)
+3. Prepend `Please` if no imperative verb detected
+4. Capitalize first letter
+5. Ensure ends with punctuation
+
+## Module structure
+
+```
+src/
+├── index.ts          ← public API re-exports
+├── enhancer.ts       ← enhance() orchestrator
+├── modifiers.ts      ← built-in modifier definitions + resolveModifier()
+├── model-adapter.ts  ← ModelAdapter interface + RuleBasedAdapter
+├── diff.ts           ← computeDiff(), formatDiffMarkdown()
+├── history.ts        ← HistoryManager, HistoryStorage, InMemoryStorage
+└── rule-based.ts     ← ruleBasedEnhance() — :fast mode logic
+```
+
+## Development
+
+```bash
+# Build (CJS + ESM + .d.ts)
+pnpm --filter @promptrev/core build
+
+# Watch mode
+pnpm --filter @promptrev/core watch
+
+# Tests
+pnpm --filter @promptrev/core test
+
+# Typecheck only
+pnpm --filter @promptrev/core typecheck
+```

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -1,0 +1,153 @@
+# PromptRev — VS Code Extension
+
+> Instantly enhance your AI prompts with `@rev` — before you send them.
+
+PromptRev makes every developer a prompt engineer without them needing to think about it. Type `@rev your rough prompt` in any VS Code Chat panel and get a polished, context-aware version back in under a second — with a diff showing exactly what changed.
+
+## How it works
+
+```mermaid
+sequenceDiagram
+    participant Dev as Developer
+    participant Chat as VS Code Chat
+    participant Rev as @rev participant
+    participant LM as vscode.lm (Copilot/Claude)
+
+    Dev->>Chat: @rev fix the bug in my auth module
+    Chat->>Rev: handler(request)
+    Rev->>LM: enhance with default modifier
+    LM-->>Rev: polished prompt
+    Rev-->>Chat: diff preview + revised prompt
+    Dev->>Chat: copies revised prompt → sends to AI
+```
+
+No separate API key required. PromptRev reuses whatever model you already have active (GitHub Copilot, Claude, etc.) via VS Code's `vscode.lm` API. If no model is available, it falls back to rule-based enhancement automatically.
+
+## Features
+
+- **`@rev` Chat Participant** — first-class VS Code Chat integration with autocomplete
+- **6 built-in modifiers** — `:fast`, `:deep`, `:architect`, `:critic`, `:spell`, `:spec`
+- **`Cmd+Shift+E`** — enhance selected text in any editor without opening chat
+- **Diff preview** — see exactly what changed before accepting
+- **Prompt history panel** — restore, review, and export past enhancements
+- **Zero setup** — no API key, no background process, works with your existing model
+- **Custom modifiers** — define team-specific enhancement rules in `.promptrev.json`
+
+## Usage
+
+### `@rev` in VS Code Chat
+
+Type `@rev` followed by your prompt in any VS Code Chat panel:
+
+```
+@rev fix the bug in my auth module
+```
+
+PromptRev intercepts the message, enhances it, and returns a diff preview with the revised prompt ready to copy.
+
+### Modifiers
+
+Append a modifier with `/` in the chat command:
+
+| Command | Best for |
+|---|---|
+| `@rev` | Everyday prompts — clarity, structure, context |
+| `@rev /fast` | In-flow quick fixes — rule-based, zero latency, auto-accept |
+| `@rev /deep` | Complex tasks — chain-of-thought, edge cases, structure |
+| `@rev /architect` | System design — trade-offs, components, scalability |
+| `@rev /critic` | Code review — failure modes, security, assumptions |
+| `@rev /spell` | Grammar and spelling only — no restructuring |
+| `@rev /spec` | Convert a vague idea into a structured spec |
+
+### Keybinding — enhance selected text
+
+Select any text in the editor and press `Cmd+Shift+E` (Mac) or `Ctrl+Shift+E` (Windows/Linux):
+
+1. Select your rough prompt text in any file
+2. Press the keybinding
+3. Choose **Replace Selection**, **Copy to Clipboard**, or **Dismiss**
+
+Works in `.md` files, scratch files, code comments — anywhere you draft prompts.
+
+## Configuration
+
+All settings live in VS Code `settings.json` under the `promptrev.*` namespace:
+
+```json
+{
+  "promptrev.acceptMode": "diff",
+  "promptrev.autoSend": false,
+  "promptrev.keepHistory": true,
+  "promptrev.maxHistory": 100,
+  "promptrev.domainContext": "React + TypeScript, Node.js, PostgreSQL",
+  "promptrev.modifiers": {
+    "fast": { "autoSend": true },
+    "backend": {
+      "systemPrompt": "Rewrite for a TypeScript/Express backend. Always include error handling, input validation, and Prisma/PostgreSQL context.",
+      "acceptMode": "diff"
+    }
+  }
+}
+```
+
+| Setting | Default | Description |
+|---|---|---|
+| `promptrev.acceptMode` | `"diff"` | `"diff"` shows a preview, `"auto"` accepts immediately |
+| `promptrev.autoSend` | `false` | Auto-send accepted prompt to the AI |
+| `promptrev.keepHistory` | `true` | Track enhancement history |
+| `promptrev.maxHistory` | `100` | Max history entries (1–500) |
+| `promptrev.domainContext` | `""` | Tech stack injected into every enhancement |
+| `promptrev.modifiers` | `{}` | Custom or overridden modifier definitions |
+
+### Project-level config
+
+Create a `.promptrev.json` at the workspace root to share modifier definitions with your team:
+
+```json
+{
+  "modifiers": {
+    "backend": {
+      "systemPrompt": "Rewrite this prompt for a Node.js + Express + PostgreSQL + Prisma backend. Include TypeScript, JWT auth, error handling, and input validation in every response.",
+      "acceptMode": "diff"
+    },
+    "frontend": {
+      "systemPrompt": "Rewrite this prompt for a React + TypeScript frontend. Include accessibility, component structure, and state management considerations.",
+      "acceptMode": "diff"
+    }
+  }
+}
+```
+
+## Model fallback chain
+
+```mermaid
+flowchart LR
+    A[Enhancement request] --> B{vscode.lm available?}
+    B -->|yes| C[Use active Copilot/Claude model]
+    B -->|no| D{API key configured?}
+    D -->|yes| E[Use configured API key]
+    D -->|no| F{modifier = :fast?}
+    F -->|yes| G[Rule-based enhancement]
+    F -->|no| H[Show: No model available]
+```
+
+## Requirements
+
+- VS Code `^1.85.0`
+- GitHub Copilot (recommended) or another VS Code language model extension
+
+## Development
+
+```bash
+# From monorepo root
+pnpm install
+pnpm build:core
+
+# Build the extension
+pnpm --filter @promptrev/vscode build
+
+# Watch mode
+pnpm --filter @promptrev/vscode watch
+
+# Press F5 in VS Code to launch Extension Development Host
+```


### PR DESCRIPTION
## Summary

Closes #25 — documentation for repo root, core, and vscode packages, plus a contributor guide.

## What's included

**Root [`README.md`](README.md)**
- Mermaid architecture diagram (how VS Code + CLI connect to core)
- Package dependency diagram (core ← vscode, core ← cli)
- Modifier quick reference table with latency and auto-send info
- Updated monorepo structure tree with CI callout

**[`packages/core/README.md`](packages/core/README.md)**
- Sequence diagram: prompt flow through `enhance()` end-to-end
- Flowchart: modifier resolution logic
- Full public API docs: `enhance()`, `resolveModifier()`, `ModelAdapter`, `HistoryManager`, diff utils, `ruleBasedEnhance()`
- Custom adapter example (OpenAI)
- Built-in modifier reference table

**[`packages/vscode/README.md`](packages/vscode/README.md)**
- Marketplace-ready listing (this becomes the VS Code Marketplace page)
- Sequence diagram: `@rev` chat participant flow
- Modifier usage table, keybinding instructions
- Full `settings.json` configuration reference
- `.promptrev.json` team config example
- Model fallback chain flowchart

**[`CONTRIBUTING.md`](CONTRIBUTING.md)**
- Prerequisites and local setup
- Build order explanation (core → vscode → cli) with Mermaid graph
- Per-package dev workflow (watch, test, typecheck, F5)
- Branching, commit message, and PR conventions
- CI pipeline overview
- Step-by-step: how to add a new modifier

## Notes

- `packages/cli/README.md` is intentionally omitted — will be added in the CLI scaffold PR (#19)
- All Mermaid diagrams render natively on GitHub — no build step needed
- Docs are written to be kept current as features land; structure is intentionally stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)