### PR TITLE
infra: add VS Code launch config for extension development host

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode",
+    "vitest.explorer"
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,31 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Launch Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}/packages/vscode"
+      ],
+      "outFiles": [
+        "${workspaceFolder}/packages/vscode/dist/**/*.js"
+      ],
+      "preLaunchTask": "build-vscode",
+      "sourceMaps": true
+    },
+    {
+      "name": "Launch Extension (watch)",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}/packages/vscode"
+      ],
+      "outFiles": [
+        "${workspaceFolder}/packages/vscode/dist/**/*.js"
+      ],
+      "preLaunchTask": "watch-vscode",
+      "sourceMaps": true
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -22,7 +22,7 @@
         "reveal": "silent",
         "panel": "shared"
       },
-      "problemMatcher": "$esbuild-watch"
+      "problemMatcher": []
     },
     {
       "label": "watch-vscode",
@@ -33,8 +33,7 @@
       "isBackground": true,
       "presentation": {
         "reveal": "always",
-        "panel": "dedicated",
-        "label": "PromptRev Watch"
+        "panel": "dedicated"
       },
       "problemMatcher": {
         "owner": "esbuild",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,57 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build-core",
+      "type": "shell",
+      "command": "pnpm --filter @promptrev/core build",
+      "group": "build",
+      "presentation": {
+        "reveal": "silent",
+        "panel": "shared"
+      },
+      "problemMatcher": "$tsc"
+    },
+    {
+      "label": "build-vscode",
+      "type": "shell",
+      "command": "pnpm --filter @promptrev/vscode build",
+      "group": "build",
+      "dependsOn": "build-core",
+      "presentation": {
+        "reveal": "silent",
+        "panel": "shared"
+      },
+      "problemMatcher": "$esbuild-watch"
+    },
+    {
+      "label": "watch-vscode",
+      "type": "shell",
+      "command": "pnpm --filter @promptrev/vscode watch",
+      "group": "build",
+      "dependsOn": "build-core",
+      "isBackground": true,
+      "presentation": {
+        "reveal": "always",
+        "panel": "dedicated",
+        "label": "PromptRev Watch"
+      },
+      "problemMatcher": {
+        "owner": "esbuild",
+        "pattern": {
+          "regexp": "^(.*):(\\d+):(\\d+): (error|warning): (.*)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "severity": 4,
+          "message": 5
+        },
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": "^\\[watch\\] build started",
+          "endsPattern": "^\\[watch\\] build finished"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the `.vscode/` config needed to run and debug the extension locally with F5.

## Files

- **`.vscode/launch.json`** — two launch configurations:
  - `Launch Extension` — builds once then opens the Extension Development Host
  - `Launch Extension (watch)` — starts watch mode, dev host auto-reloads on changes
- **`.vscode/tasks.json`** — three tasks with the correct dependency chain:
  - `build-core` → runs `pnpm --filter @promptrev/core build`
  - `build-vscode` → depends on `build-core`, runs `pnpm --filter @promptrev/vscode build`
  - `watch-vscode` → depends on `build-core`, runs watch mode as a background task
- **`.vscode/extensions.json`** — recommends ESLint, Prettier, and Vitest Explorer for new contributors

## How to use

1. Open the monorepo root in VS Code
2. Press `F5` (or Run → Start Debugging → "Launch Extension")
3. A second VS Code window opens — the Extension Development Host
4. In that window, open any Chat panel and type `@rev` to test

For active development, use `Launch Extension (watch)` — the extension rebuilds automatically on file changes and you can reload the dev host with `Ctrl+R`.

## Test plan

- [x] `pnpm build:core && pnpm --filter @promptrev/vscode build` — clean, no errors
- [x] `.gitignore` confirmed not excluding `.vscode/` (only `.vscode-test` is excluded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)