### PR TITLE
feat(core,vscode): add prompt quality signal to enhancement response

### DIFF
--- a/packages/core/src/__tests__/enhancer.test.ts
+++ b/packages/core/src/__tests__/enhancer.test.ts
@@ -78,6 +78,32 @@ describe('enhance', () => {
     expect(result.original).toBe('fix the bug in my module');
   });
 
+  it('parses JSON response and populates signal', async () => {
+    const jsonResponse = JSON.stringify({
+      revised: 'Fix the authentication bug in the login module.',
+      signal: 'Added specificity and scope',
+    });
+    const adapter = makeMockAdapter(jsonResponse);
+    const result = await enhance({
+      rawPrompt: 'fix the auth bug',
+      modifier: 'default',
+      modelAdapter: adapter,
+    });
+    expect(result.revised).toBe('Fix the authentication bug in the login module.');
+    expect(result.signal).toBe('Added specificity and scope');
+  });
+
+  it('falls back gracefully when LLM returns plain text instead of JSON', async () => {
+    const adapter = makeMockAdapter('Fix the authentication bug in the login module.');
+    const result = await enhance({
+      rawPrompt: 'fix the auth bug',
+      modifier: 'default',
+      modelAdapter: adapter,
+    });
+    expect(result.revised).toBe('Fix the authentication bug in the login module.');
+    expect(result.signal).toBeUndefined();
+  });
+
   it('propagates AbortError from modelAdapter', async () => {
     const abortError = new Error('Aborted');
     abortError.name = 'AbortError';

--- a/packages/core/src/enhancer.ts
+++ b/packages/core/src/enhancer.ts
@@ -21,9 +21,34 @@ export interface EnhancerOutput {
   /** true if the prompt was too short or already well-formed — no changes made */
   skipped: boolean;
   diff: DiffChunk[];
+  /** One-line description of what the enhancement changed, e.g. "Added output format and constraints" */
+  signal?: string;
 }
 
 const MIN_PROMPT_LENGTH = 5;
+
+/**
+ * Parses LLM response — expects JSON { revised, signal } but falls back
+ * gracefully to plain text if the model doesn't follow the format.
+ */
+function parseEnhancerResponse(raw: string): { revised: string; signal?: string } {
+  const trimmed = raw.trim();
+  // Strip optional ```json ... ``` fence the LLM sometimes adds
+  const fenceMatch = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/);
+  const candidate = fenceMatch ? fenceMatch[1].trim() : trimmed;
+  try {
+    const parsed = JSON.parse(candidate);
+    if (typeof parsed?.revised === 'string') {
+      return {
+        revised: parsed.revised.trim(),
+        signal: typeof parsed.signal === 'string' ? parsed.signal.trim() || undefined : undefined,
+      };
+    }
+  } catch {
+    // Not JSON — treat entire response as revised text, no signal
+  }
+  return { revised: trimmed };
+}
 
 /**
  * Interpolates {domainContext} placeholder in a system prompt.
@@ -58,6 +83,7 @@ export async function enhance(input: EnhancerInput): Promise<EnhancerOutput> {
   const modifierDef = resolveModifier(modifier as string, userModifiers);
 
   let revised: string;
+  let qualitySignal: string | undefined;
 
   if (!modifierDef.useLLM) {
     // :fast mode — rule-based only, no LLM call
@@ -66,8 +92,8 @@ export async function enhance(input: EnhancerInput): Promise<EnhancerOutput> {
     const systemPrompt = interpolateSystemPrompt(modifierDef.systemPrompt, domainContext);
 
     try {
-      revised = await modelAdapter.complete(systemPrompt, rawPrompt, signal);
-      revised = revised.trim();
+      const raw = await modelAdapter.complete(systemPrompt, rawPrompt, signal);
+      ({ revised, signal: qualitySignal } = parseEnhancerResponse(raw));
     } catch (err) {
       // If LLM call fails, fall back to rule-based
       if (err instanceof Error && err.name === 'AbortError') {
@@ -93,5 +119,6 @@ export async function enhance(input: EnhancerInput): Promise<EnhancerOutput> {
     timestamp,
     skipped,
     diff,
+    signal: qualitySignal,
   };
 }

--- a/packages/core/src/modifiers.ts
+++ b/packages/core/src/modifiers.ts
@@ -31,7 +31,12 @@ Rules:
 - Fix grammar and spelling
 - Remove vague filler language
 - Do not make the prompt longer than necessary
-- Return ONLY the rewritten prompt — no explanation, no preamble
+
+Return a JSON object with exactly two fields:
+- "revised": the rewritten prompt
+- "signal": a concise one-line description of what changed (e.g. "Added output format and scope constraints")
+
+Example: {"revised": "...", "signal": "Added output format and domain context"}
 
 Domain context (if provided): {domainContext}`;
 
@@ -44,7 +49,7 @@ Add:
 - Output structure (numbered sections, headers)
 - "Think step by step" closing instruction
 
-Return ONLY the rewritten prompt.`;
+Return a JSON object: {"revised": "<rewritten prompt>", "signal": "<one-line description of what changed>"}`;
 
 const ARCHITECT_SYSTEM_PROMPT = `You are a software architect and prompt engineer. Rewrite this prompt to elicit a thorough architectural analysis.
 
@@ -55,7 +60,7 @@ Focus on:
 - Decision points that require explicit choices
 - Output structure with clear sections
 
-Return ONLY the rewritten prompt.`;
+Return a JSON object: {"revised": "<rewritten prompt>", "signal": "<one-line description of what changed>"}`
 
 const CRITIC_SYSTEM_PROMPT = `You are an adversarial reviewer and prompt engineer. Rewrite this prompt to elicit critical, failure-focused analysis.
 
@@ -66,7 +71,7 @@ Reframe the prompt to:
 - Request the top 3 highest-priority improvements
 - Emphasize: do not just describe what the code does — focus on what could go wrong
 
-Return ONLY the rewritten prompt.`;
+Return a JSON object: {"revised": "<rewritten prompt>", "signal": "<one-line description of what changed>"}`
 
 const SPELL_SYSTEM_PROMPT = `You are a grammar and spelling corrector. Fix only spelling mistakes and grammatical errors in the user's prompt.
 
@@ -75,7 +80,8 @@ Rules:
 - Do NOT add context, output format requirements, or extra instructions
 - Fix only: typos, misspellings, grammar errors, punctuation
 - Preserve the user's original words and structure as much as possible
-- Return ONLY the corrected prompt`;
+
+Return a JSON object: {"revised": "<corrected prompt>", "signal": "<one-line description, e.g. 'Fixed 3 spelling errors and punctuation'>"}`;
 
 const SPEC_SYSTEM_PROMPT = `You are a product and engineering spec writer. Convert the user's vague idea into a structured specification prompt.
 
@@ -87,7 +93,7 @@ The rewritten prompt should ask the AI to produce:
 - Out-of-scope items
 - Open questions
 
-Return ONLY the rewritten prompt that will elicit this structured spec.`;
+Return a JSON object: {"revised": "<rewritten prompt>", "signal": "<one-line description of what changed>"}`;
 
 export const BUILT_IN_MODIFIERS: Record<string, ModifierDefinition> = {
   default: {

--- a/packages/vscode/src/participant.ts
+++ b/packages/vscode/src/participant.ts
@@ -94,8 +94,11 @@ function renderResult(
   // Register result by timestamp — consumed on first button click
   addPendingResult(result);
 
-  // Lead with the outcome: revised prompt first, prominently
-  stream.markdown('✨ **Prompt improved** — revised prompt ready to send:\n\n');
+  // Lead with signal if available, then revised prompt
+  const signalLine = result.signal
+    ? `✨ ${result.signal}`
+    : '✨ **Prompt improved** — revised prompt ready to send:';
+  stream.markdown(`${signalLine}\n\n`);
   stream.markdown(`\`\`\`\n${result.revised}\n\`\`\``);
 
   // Diff below as secondary context


### PR DESCRIPTION
Closes #35

## Summary
- LLM system prompts now return structured JSON `{ revised, signal }` instead of plain text
- `enhance()` in `@promptrev/core` parses the JSON response and exposes `signal?: string` on `EnhancerOutput`
- Graceful plain-text fallback — if the model doesn't follow the format, `revised` is set to the raw response and `signal` is `undefined`
- VS Code participant renders the signal as the opening line: `✨ Added output format and scope constraints`

## What changes in the chat UI

**Before:**
```
✨ Prompt improved — revised prompt ready to send:
```fix the auth bug in the app```
```

**After (with signal):**
```
✨ Added specificity and module context

```Fix the authentication bug in the login module.```
```

## Test plan
- [x] Two new unit tests in `enhancer.test.ts`: JSON parsing path and plain-text fallback
- [x] All 37 core tests pass
- [x] `tsc --noEmit` clean on vscode package

🤖 Generated with [Claude Code](https://claude.com/claude-code)