### PR TITLE
feat(vscode): history panel and globalState persistence — v0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "scripts": {
     "build": "pnpm --filter @promptrev/core build && pnpm --filter @promptrev/vscode build && pnpm --filter promptrev build",
     "build:core": "pnpm --filter @promptrev/core build",
+    "build:cli": "pnpm --filter promptrev build",
+    "dev:cli": "pnpm --filter @promptrev/core build && pnpm --filter promptrev build",
     "test": "pnpm -r test",
+    "test:cli": "pnpm --filter promptrev test",
     "test:core": "pnpm --filter @promptrev/core test",
     "lint": "eslint packages/*/src --ext .ts",
     "format": "prettier --write packages/*/src/**/*.ts",

--- a/packages/vscode/src/commands.ts
+++ b/packages/vscode/src/commands.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import type { EnhancerOutput } from '@promptrev/core';
+import type { HistoryPanelProvider } from './history-panel';
 
 // Keyed by result.timestamp — each enhancement gets a unique ID.
 // Entries are deleted on first use so re-clicking a button has no effect.
@@ -15,8 +16,12 @@ function consumeResult(timestamp: number): EnhancerOutput | undefined {
   return result;
 }
 
-export function registerCommands(context: vscode.ExtensionContext): void {
+export function registerCommands(context: vscode.ExtensionContext, _historyPanel: HistoryPanelProvider): void {
   context.subscriptions.push(
+    vscode.commands.registerCommand('promptrev.openHistory', () => {
+      void vscode.commands.executeCommand('promptrev.history.focus');
+    }),
+
     vscode.commands.registerCommand('promptrev.accept', async (timestamp?: number) => {
       const result = timestamp !== undefined ? consumeResult(timestamp) : undefined;
       if (!result) {

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -2,11 +2,21 @@ import * as vscode from 'vscode';
 import { registerParticipant } from './participant';
 import { registerKeybinding } from './keybinding';
 import { registerCommands } from './commands';
+import { initHistoryManager } from './history-manager';
+import { HistoryPanelProvider } from './history-panel';
 
 export function activate(context: vscode.ExtensionContext): void {
-  registerCommands(context);
-  registerParticipant(context);
-  registerKeybinding(context);
+  initHistoryManager(context);
+
+  const historyPanel = new HistoryPanelProvider(context.extensionUri);
+
+  context.subscriptions.push(
+    vscode.window.registerWebviewViewProvider(HistoryPanelProvider.viewId, historyPanel)
+  );
+
+  registerCommands(context, historyPanel);
+  registerParticipant(context, historyPanel);
+  registerKeybinding(context, historyPanel);
 }
 
 export function deactivate(): void {}

--- a/packages/vscode/src/history-manager.ts
+++ b/packages/vscode/src/history-manager.ts
@@ -1,0 +1,20 @@
+import * as vscode from 'vscode';
+import { HistoryManager } from '@promptrev/core';
+import { GlobalStateStorage } from './history-storage';
+
+let _manager: HistoryManager | undefined;
+
+export function initHistoryManager(context: vscode.ExtensionContext): HistoryManager {
+  const config = vscode.workspace.getConfiguration('promptrev');
+  const maxEntries = config.get<number>('maxHistory') ?? 100;
+  const storage = new GlobalStateStorage(context.globalState);
+  _manager = new HistoryManager(storage, maxEntries);
+  return _manager;
+}
+
+export function getHistoryManager(): HistoryManager {
+  if (!_manager) {
+    throw new Error('HistoryManager not initialized — call initHistoryManager first.');
+  }
+  return _manager;
+}

--- a/packages/vscode/src/history-panel.ts
+++ b/packages/vscode/src/history-panel.ts
@@ -1,0 +1,291 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+import type { HistoryEntry } from '@promptrev/core';
+import { getHistoryManager } from './history-manager';
+
+type WebviewMessage =
+  | { type: 'restore'; id: string }
+  | { type: 'export' }
+  | { type: 'clear' };
+
+export class HistoryPanelProvider implements vscode.WebviewViewProvider {
+  static readonly viewId = 'promptrev.history';
+
+  private _view?: vscode.WebviewView;
+
+  constructor(private readonly _extensionUri: vscode.Uri) {}
+
+  resolveWebviewView(
+    webviewView: vscode.WebviewView,
+    _context: vscode.WebviewViewResolveContext,
+    _token: vscode.CancellationToken
+  ): void {
+    this._view = webviewView;
+
+    webviewView.webview.options = {
+      enableScripts: true,
+      localResourceRoots: [this._extensionUri],
+    };
+
+    webviewView.webview.html = this._buildHtml(webviewView.webview);
+
+    webviewView.webview.onDidReceiveMessage(async (message: WebviewMessage) => {
+      const manager = getHistoryManager();
+
+      switch (message.type) {
+        case 'restore': {
+          const original = manager.restore(message.id);
+          if (original) {
+            await vscode.env.clipboard.writeText(original);
+            vscode.window.showInformationMessage('PromptRev: Original prompt copied to clipboard.');
+          }
+          break;
+        }
+        case 'export': {
+          await this._exportHistory(manager.export());
+          break;
+        }
+        case 'clear': {
+          const confirm = await vscode.window.showWarningMessage(
+            'Clear all PromptRev history?',
+            { modal: true },
+            'Clear'
+          );
+          if (confirm === 'Clear') {
+            manager.clear();
+            this.refresh();
+          }
+          break;
+        }
+      }
+    });
+  }
+
+  /** Call after each enhancement to push updated entries to the panel. */
+  refresh(): void {
+    if (!this._view) return;
+    const entries = getHistoryManager().getAll();
+    void this._view.webview.postMessage({ type: 'update', entries });
+  }
+
+  private async _exportHistory(json: string): Promise<void> {
+    const folders = vscode.workspace.workspaceFolders;
+    const rootUri = folders?.[0]?.uri;
+
+    if (!rootUri) {
+      // No workspace — write to clipboard instead
+      await vscode.env.clipboard.writeText(json);
+      vscode.window.showInformationMessage('PromptRev: History JSON copied to clipboard (no workspace open).');
+      return;
+    }
+
+    const fileUri = vscode.Uri.joinPath(rootUri, 'promptrev-history.json');
+    await vscode.workspace.fs.writeFile(fileUri, Buffer.from(json, 'utf8'));
+    const open = await vscode.window.showInformationMessage(
+      'PromptRev: History exported to promptrev-history.json',
+      'Open File'
+    );
+    if (open === 'Open File') {
+      await vscode.window.showTextDocument(fileUri);
+    }
+  }
+
+  private _buildHtml(webview: vscode.Webview): string {
+    const nonce = getNonce();
+
+    return /* html */ `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy"
+    content="default-src 'none'; style-src 'nonce-${nonce}'; script-src 'nonce-${nonce}';">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <style nonce="${nonce}">
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: var(--vscode-font-family);
+      font-size: var(--vscode-font-size);
+      color: var(--vscode-foreground);
+      background: var(--vscode-sideBar-background);
+      padding: 8px;
+    }
+
+    .toolbar {
+      display: flex;
+      gap: 6px;
+      margin-bottom: 10px;
+    }
+
+    button {
+      font-family: var(--vscode-font-family);
+      font-size: 11px;
+      padding: 3px 8px;
+      cursor: pointer;
+      border: 1px solid var(--vscode-button-border, transparent);
+      border-radius: 2px;
+      background: var(--vscode-button-secondaryBackground);
+      color: var(--vscode-button-secondaryForeground);
+    }
+    button:hover {
+      background: var(--vscode-button-secondaryHoverBackground);
+    }
+    button.primary {
+      background: var(--vscode-button-background);
+      color: var(--vscode-button-foreground);
+    }
+    button.primary:hover {
+      background: var(--vscode-button-hoverBackground);
+    }
+    button.danger {
+      background: var(--vscode-inputValidation-errorBackground);
+      color: var(--vscode-errorForeground);
+      border-color: var(--vscode-inputValidation-errorBorder, transparent);
+    }
+
+    .empty {
+      color: var(--vscode-descriptionForeground);
+      font-style: italic;
+      padding: 12px 4px;
+    }
+
+    .entry {
+      border: 1px solid var(--vscode-widget-border, var(--vscode-panel-border));
+      border-radius: 4px;
+      margin-bottom: 8px;
+      overflow: hidden;
+    }
+
+    .entry-header {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      padding: 5px 8px;
+      background: var(--vscode-sideBarSectionHeader-background);
+      border-bottom: 1px solid var(--vscode-widget-border, var(--vscode-panel-border));
+    }
+
+    .badge {
+      font-size: 10px;
+      padding: 1px 5px;
+      border-radius: 10px;
+      background: var(--vscode-badge-background);
+      color: var(--vscode-badge-foreground);
+      text-transform: uppercase;
+      letter-spacing: 0.3px;
+    }
+
+    .timestamp {
+      color: var(--vscode-descriptionForeground);
+      font-size: 11px;
+      margin-left: auto;
+    }
+
+    .entry-body {
+      padding: 7px 8px;
+    }
+
+    .label {
+      font-size: 10px;
+      text-transform: uppercase;
+      letter-spacing: 0.4px;
+      color: var(--vscode-descriptionForeground);
+      margin-bottom: 2px;
+    }
+
+    .snippet {
+      font-family: var(--vscode-editor-font-family, monospace);
+      font-size: 11px;
+      color: var(--vscode-editor-foreground);
+      background: var(--vscode-editor-background);
+      border-radius: 2px;
+      padding: 4px 6px;
+      margin-bottom: 6px;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+
+    .entry-footer {
+      padding: 5px 8px 7px;
+      display: flex;
+      gap: 5px;
+    }
+  </style>
+</head>
+<body>
+  <div class="toolbar">
+    <button class="primary" id="btn-export">Export JSON</button>
+    <button class="danger" id="btn-clear">Clear History</button>
+  </div>
+
+  <div id="list"><p class="empty">No history yet. Enhance a prompt with @rev to get started.</p></div>
+
+  <script nonce="${nonce}">
+    const vscode = acquireVsCodeApi();
+
+    document.getElementById('btn-export').addEventListener('click', () => {
+      vscode.postMessage({ type: 'export' });
+    });
+
+    document.getElementById('btn-clear').addEventListener('click', () => {
+      vscode.postMessage({ type: 'clear' });
+    });
+
+    function truncate(text, max) {
+      return text.length > max ? text.slice(0, max) + '…' : text;
+    }
+
+    function timeAgo(ts) {
+      const diff = Math.floor((Date.now() - ts) / 1000);
+      if (diff < 60) return diff + 's ago';
+      if (diff < 3600) return Math.floor(diff / 60) + 'm ago';
+      if (diff < 86400) return Math.floor(diff / 3600) + 'h ago';
+      return Math.floor(diff / 86400) + 'd ago';
+    }
+
+    function renderEntries(entries) {
+      const list = document.getElementById('list');
+      if (!entries.length) {
+        list.innerHTML = '<p class="empty">No history yet. Enhance a prompt with @rev to get started.</p>';
+        return;
+      }
+      list.innerHTML = entries.map(e => \`
+        <div class="entry">
+          <div class="entry-header">
+            <span class="badge">\${e.modifier}</span>
+            <span class="timestamp">\${timeAgo(e.timestamp)}</span>
+          </div>
+          <div class="entry-body">
+            <div class="label">Original</div>
+            <div class="snippet">\${escHtml(truncate(e.original, 120))}</div>
+            <div class="label">Revised</div>
+            <div class="snippet">\${escHtml(truncate(e.revised, 120))}</div>
+          </div>
+          <div class="entry-footer">
+            <button onclick="restore('\${e.id}')">Restore Original</button>
+          </div>
+        </div>
+      \`).join('');
+    }
+
+    function escHtml(s) {
+      return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+    }
+
+    function restore(id) {
+      vscode.postMessage({ type: 'restore', id });
+    }
+
+    window.addEventListener('message', e => {
+      if (e.data.type === 'update') renderEntries(e.data.entries);
+    });
+  </script>
+</body>
+</html>`;
+  }
+}
+
+function getNonce(): string {
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  return Array.from({ length: 32 }, () => chars[Math.floor(Math.random() * chars.length)]).join('');
+}

--- a/packages/vscode/src/history-storage.ts
+++ b/packages/vscode/src/history-storage.ts
@@ -1,0 +1,21 @@
+import * as vscode from 'vscode';
+import type { HistoryStorage, HistoryEntry } from '@promptrev/core';
+
+const STATE_KEY = 'promptrev.history';
+
+/**
+ * VS Code globalState-backed storage for HistoryManager.
+ * Entries survive extension restarts and VS Code sessions.
+ */
+export class GlobalStateStorage implements HistoryStorage {
+  constructor(private readonly globalState: vscode.Memento) {}
+
+  get(): HistoryEntry[] {
+    return this.globalState.get<HistoryEntry[]>(STATE_KEY) ?? [];
+  }
+
+  set(entries: HistoryEntry[]): void {
+    // Fire-and-forget — globalState.update returns a Promise but errors are non-fatal
+    void this.globalState.update(STATE_KEY, entries);
+  }
+}

--- a/packages/vscode/src/keybinding.ts
+++ b/packages/vscode/src/keybinding.ts
@@ -2,8 +2,10 @@ import * as vscode from 'vscode';
 import { enhance, RuleBasedAdapter } from '@promptrev/core';
 import { VSCodeModelAdapter } from './vscode-model-adapter';
 import { selectModel } from './model-selector';
+import { getHistoryManager } from './history-manager';
+import type { HistoryPanelProvider } from './history-panel';
 
-export function registerKeybinding(context: vscode.ExtensionContext): void {
+export function registerKeybinding(context: vscode.ExtensionContext, historyPanel: HistoryPanelProvider): void {
   const cmd = vscode.commands.registerCommand('promptrev.enhanceSelection', async () => {
     const editor = vscode.window.activeTextEditor;
     if (!editor) return;
@@ -39,6 +41,14 @@ export function registerKeybinding(context: vscode.ExtensionContext): void {
         vscode.window.showInformationMessage('PromptRev: No significant changes needed.');
         return;
       }
+
+      getHistoryManager().add({
+        original: result.original,
+        revised: result.revised,
+        modifier: result.modifier as string,
+        accepted: false,
+      });
+      historyPanel.refresh();
 
       const choice = await vscode.window.showInformationMessage(
         `PromptRev: Prompt enhanced. Replace selection or copy to clipboard?`,

--- a/packages/vscode/src/participant.ts
+++ b/packages/vscode/src/participant.ts
@@ -5,9 +5,13 @@ import { VSCodeModelAdapter } from './vscode-model-adapter';
 import { parseModifierFromCommand } from './utils';
 import { selectModel, handleNoModel } from './model-selector';
 import { addPendingResult } from './commands';
+import { getHistoryManager } from './history-manager';
+import type { HistoryPanelProvider } from './history-panel';
 
-export function registerParticipant(context: vscode.ExtensionContext): void {
-  const participant = vscode.chat.createChatParticipant('promptrev.rev', handler);
+export function registerParticipant(context: vscode.ExtensionContext, historyPanel: HistoryPanelProvider): void {
+  const participant = vscode.chat.createChatParticipant('promptrev.rev', (req, ctx, stream, token) =>
+    handler(req, ctx, stream, token, historyPanel)
+  );
   participant.iconPath = vscode.Uri.joinPath(context.extensionUri, 'icons', 'rev.png');
   context.subscriptions.push(participant);
 }
@@ -16,7 +20,8 @@ async function handler(
   request: vscode.ChatRequest,
   _context: vscode.ChatContext,
   stream: vscode.ChatResponseStream,
-  token: vscode.CancellationToken
+  token: vscode.CancellationToken,
+  historyPanel: HistoryPanelProvider
 ): Promise<void> {
   const modifier = parseModifierFromCommand(request.command);
   const rawPrompt = request.prompt.trim();
@@ -66,6 +71,15 @@ async function handler(
       );
       return;
     }
+
+    // Record to history and refresh the panel
+    getHistoryManager().add({
+      original: result.original,
+      revised: result.revised,
+      modifier: result.modifier as string,
+      accepted: false,
+    });
+    historyPanel.refresh();
 
     // :fast and any modifier with acceptMode:'auto' — skip diff, show result directly (#13)
     if (modifierDef.acceptMode === 'auto') {


### PR DESCRIPTION
Closes #17
Closes #18

## Summary
- **`GlobalStateStorage`** — `HistoryStorage` implementation backed by `vscode.ExtensionContext.globalState`. History survives VS Code restarts and handles missing/empty state on first use.
- **`HistoryPanelProvider`** — `WebviewViewProvider` registered as `promptrev.history` in the Explorer sidebar
- **`HistoryManager`** initialised on activation, shared across participant and keybinding flows

## History panel features
- Lists entries newest-first: modifier badge, relative timestamp (`2m ago`), truncated original and revised snippets
- **Restore Original** — copies the original prompt to clipboard per entry
- **Export JSON** — writes `promptrev-history.json` to workspace root (clipboard fallback if no workspace)
- **Clear History** — modal confirmation before clearing
- Panel auto-refreshes after every `@rev` chat enhancement and every `Cmd+Shift+E` keybinding enhancement
- `promptrev.openHistory` command focuses the panel

## Test with F5
1. Press F5 → Extension Development Host
2. Use `@rev fix the auth bug` in chat
3. Open Explorer sidebar → **PromptRev History** — entry appears immediately
4. Click **Restore Original** — original copied to clipboard
5. Restart VS Code — history still present (globalState persistence)
6. Click **Export JSON** — `promptrev-history.json` created in workspace root
7. Click **Clear History** → confirm — list clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)