### PR TITLE
feat(vscode): .promptrev.json project config and custom modifier fallback — v0.6.0

### DIFF
--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -4,19 +4,24 @@ import { registerKeybinding } from './keybinding';
 import { registerCommands } from './commands';
 import { initHistoryManager } from './history-manager';
 import { HistoryPanelProvider } from './history-panel';
+import { ProjectConfigProvider } from './project-config';
 
 export function activate(context: vscode.ExtensionContext): void {
   initHistoryManager(context);
 
   const historyPanel = new HistoryPanelProvider(context.extensionUri);
+  const projectConfig = new ProjectConfigProvider(context);
 
   context.subscriptions.push(
     vscode.window.registerWebviewViewProvider(HistoryPanelProvider.viewId, historyPanel)
   );
 
+  // Load .promptrev.json asynchronously — participant/keybinding read it on each invocation
+  void projectConfig.init();
+
   registerCommands(context, historyPanel);
-  registerParticipant(context, historyPanel);
-  registerKeybinding(context, historyPanel);
+  registerParticipant(context, historyPanel, projectConfig);
+  registerKeybinding(context, historyPanel, projectConfig);
 }
 
 export function deactivate(): void {}

--- a/packages/vscode/src/keybinding.ts
+++ b/packages/vscode/src/keybinding.ts
@@ -4,8 +4,13 @@ import { VSCodeModelAdapter } from './vscode-model-adapter';
 import { selectModel } from './model-selector';
 import { getHistoryManager } from './history-manager';
 import type { HistoryPanelProvider } from './history-panel';
+import type { ProjectConfigProvider } from './project-config';
 
-export function registerKeybinding(context: vscode.ExtensionContext, historyPanel: HistoryPanelProvider): void {
+export function registerKeybinding(
+  context: vscode.ExtensionContext,
+  historyPanel: HistoryPanelProvider,
+  projectConfig: ProjectConfigProvider
+): void {
   const cmd = vscode.commands.registerCommand('promptrev.enhanceSelection', async () => {
     const editor = vscode.window.activeTextEditor;
     if (!editor) return;
@@ -18,9 +23,8 @@ export function registerKeybinding(context: vscode.ExtensionContext, historyPane
       return;
     }
 
-    const config = vscode.workspace.getConfiguration('promptrev');
-    const domainContext = config.get<string>('domainContext') || undefined;
-    const userModifiers = config.get<Record<string, object>>('modifiers') || {};
+    const domainContext = projectConfig.getMergedDomainContext();
+    const userModifiers = projectConfig.getMergedModifiers();
 
     const tokenSource = new vscode.CancellationTokenSource();
     const model = await selectModel();

--- a/packages/vscode/src/participant.ts
+++ b/packages/vscode/src/participant.ts
@@ -7,10 +7,18 @@ import { selectModel, handleNoModel } from './model-selector';
 import { addPendingResult } from './commands';
 import { getHistoryManager } from './history-manager';
 import type { HistoryPanelProvider } from './history-panel';
+import type { ProjectConfigProvider } from './project-config';
 
-export function registerParticipant(context: vscode.ExtensionContext, historyPanel: HistoryPanelProvider): void {
+// Track unknown modifiers already notified this session — avoid repeated toasts
+const _notifiedUnknownModifiers = new Set<string>();
+
+export function registerParticipant(
+  context: vscode.ExtensionContext,
+  historyPanel: HistoryPanelProvider,
+  projectConfig: ProjectConfigProvider
+): void {
   const participant = vscode.chat.createChatParticipant('promptrev.rev', (req, ctx, stream, token) =>
-    handler(req, ctx, stream, token, historyPanel)
+    handler(req, ctx, stream, token, historyPanel, projectConfig)
   );
   participant.iconPath = vscode.Uri.joinPath(context.extensionUri, 'icons', 'rev.png');
   context.subscriptions.push(participant);
@@ -21,7 +29,8 @@ async function handler(
   _context: vscode.ChatContext,
   stream: vscode.ChatResponseStream,
   token: vscode.CancellationToken,
-  historyPanel: HistoryPanelProvider
+  historyPanel: HistoryPanelProvider,
+  projectConfig: ProjectConfigProvider
 ): Promise<void> {
   const modifier = parseModifierFromCommand(request.command);
   const rawPrompt = request.prompt.trim();
@@ -31,9 +40,16 @@ async function handler(
     return;
   }
 
-  const config = vscode.workspace.getConfiguration('promptrev');
-  const domainContext = config.get<string>('domainContext') || undefined;
-  const userModifiers = config.get<Record<string, object>>('modifiers') || {};
+  const domainContext = projectConfig.getMergedDomainContext();
+  const userModifiers = projectConfig.getMergedModifiers();
+
+  // Notify once per session if an unknown modifier key was typed (#23)
+  if (modifier !== 'default' && !projectConfig.isKnownModifier(modifier) && !_notifiedUnknownModifiers.has(modifier)) {
+    _notifiedUnknownModifiers.add(modifier);
+    vscode.window.showInformationMessage(
+      `PromptRev: Unknown modifier "${modifier}" — falling back to default. Define it in .promptrev.json or settings.json to use it.`
+    );
+  }
 
   // Resolve modifier definition to check acceptMode up front
   const modifierDef = resolveModifier(modifier, userModifiers);

--- a/packages/vscode/src/project-config.ts
+++ b/packages/vscode/src/project-config.ts
@@ -1,0 +1,134 @@
+import * as vscode from 'vscode';
+import { BUILT_IN_MODIFIERS } from '@promptrev/core';
+import type { ModifierDefinition } from '@promptrev/core';
+
+export interface ProjectConfig {
+  domainContext?: string;
+  modifiers?: Record<string, Partial<ModifierDefinition>>;
+}
+
+const CONFIG_FILENAME = '.promptrev.json';
+
+/**
+ * Loads, watches, and merges .promptrev.json with VS Code settings.
+ *
+ * Merge precedence (highest → lowest):
+ *   .promptrev.json  >  settings.json (promptrev.modifiers)  >  built-ins
+ *
+ * domainContext: project value prepended to the global settings value.
+ */
+export class ProjectConfigProvider {
+  private _config: ProjectConfig = {};
+  private _watcher?: vscode.FileSystemWatcher;
+  private readonly _onDidChange = new vscode.EventEmitter<ProjectConfig>();
+  readonly onDidChange = this._onDidChange.event;
+
+  constructor(private readonly _context: vscode.ExtensionContext) {}
+
+  async init(): Promise<void> {
+    await this._reload();
+    this._startWatcher();
+  }
+
+  /** Raw config from .promptrev.json only. */
+  getProjectConfig(): ProjectConfig {
+    return this._config;
+  }
+
+  /**
+   * Merged modifiers: settings.json modifiers overridden by .promptrev.json modifiers.
+   * Project config wins on key conflict.
+   */
+  getMergedModifiers(): Record<string, Partial<ModifierDefinition>> {
+    const settings = vscode.workspace
+      .getConfiguration('promptrev')
+      .get<Record<string, Partial<ModifierDefinition>>>('modifiers') ?? {};
+    return { ...settings, ...this._config.modifiers };
+  }
+
+  /**
+   * Merged domainContext: project value prepended to global settings value.
+   * e.g. project="React + TS"  global="PostgreSQL"  →  "React + TS. PostgreSQL"
+   */
+  getMergedDomainContext(): string | undefined {
+    const global =
+      vscode.workspace.getConfiguration('promptrev').get<string>('domainContext') ?? '';
+    const project = this._config.domainContext ?? '';
+    const merged = [project, global].filter(Boolean).join('. ');
+    return merged || undefined;
+  }
+
+  /**
+   * Returns true if the modifier key is known (built-in or user-defined).
+   * Used to decide whether to show the "unknown modifier" fallback notice.
+   */
+  isKnownModifier(key: string): boolean {
+    return key in BUILT_IN_MODIFIERS || key in this.getMergedModifiers();
+  }
+
+  private async _reload(): Promise<void> {
+    const folder = vscode.workspace.workspaceFolders?.[0];
+    if (!folder) {
+      this._config = {};
+      return;
+    }
+
+    const fileUri = vscode.Uri.joinPath(folder.uri, CONFIG_FILENAME);
+    try {
+      const bytes = await vscode.workspace.fs.readFile(fileUri);
+      const raw = JSON.parse(new TextDecoder().decode(bytes));
+      this._config = this._validate(raw);
+    } catch (err) {
+      if (err instanceof SyntaxError) {
+        vscode.window.showWarningMessage(
+          `PromptRev: Malformed .promptrev.json — ${err.message}. Falling back to defaults.`
+        );
+      }
+      // File absent or unreadable — silently use empty config
+      this._config = {};
+    }
+  }
+
+  private _validate(raw: unknown): ProjectConfig {
+    if (typeof raw !== 'object' || raw === null) {
+      vscode.window.showWarningMessage(
+        'PromptRev: .promptrev.json must be a JSON object. Falling back to defaults.'
+      );
+      return {};
+    }
+    const obj = raw as Record<string, unknown>;
+    const result: ProjectConfig = {};
+
+    if (typeof obj.domainContext === 'string') {
+      result.domainContext = obj.domainContext;
+    }
+
+    if (typeof obj.modifiers === 'object' && obj.modifiers !== null && !Array.isArray(obj.modifiers)) {
+      result.modifiers = obj.modifiers as Record<string, Partial<ModifierDefinition>>;
+    }
+
+    return result;
+  }
+
+  private _startWatcher(): void {
+    const folder = vscode.workspace.workspaceFolders?.[0];
+    if (!folder) return;
+
+    const pattern = new vscode.RelativePattern(folder, CONFIG_FILENAME);
+    this._watcher = vscode.workspace.createFileSystemWatcher(pattern);
+
+    const reload = async () => {
+      await this._reload();
+      this._onDidChange.fire(this._config);
+    };
+
+    this._watcher.onDidChange(reload, undefined, this._context.subscriptions);
+    this._watcher.onDidCreate(reload, undefined, this._context.subscriptions);
+    this._watcher.onDidDelete(async () => {
+      this._config = {};
+      this._onDidChange.fire(this._config);
+    }, undefined, this._context.subscriptions);
+
+    this._context.subscriptions.push(this._watcher, this._onDidChange);
+  }
+}


### PR DESCRIPTION
Closes #22
Closes #23

## Summary
- New `ProjectConfigProvider` reads and watches `.promptrev.json` in the workspace root
- Custom modifiers and domain context now merge from both `.promptrev.json` and `settings.json`
- Unknown modifier keys show a one-time notification then fall back to `default`

## `.promptrev.json` schema

```json
{
  "domainContext": "React + TypeScript, Node.js, PostgreSQL",
  "modifiers": {
    "backend": {
      "label": "Backend",
      "description": "Backend-focused prompt enhancement",
      "systemPrompt": "You are a backend engineer. Rewrite this prompt...",
      "acceptMode": "diff"
    },
    "deep": {
      "description": "Our team's deep modifier override"
    }
  }
}
```

## Merge precedence

| Source | Priority |
|---|---|
| `.promptrev.json` modifiers | Highest — wins on key conflict |
| `settings.json` modifiers | Middle |
| Built-in modifiers | Lowest fallback |

`domainContext`: project value **prepends** to global settings value, separated by `. `

## Auto-reload
The file watcher picks up saves/creates/deletes instantly — no extension restart needed.

## Unknown modifier fallback (#23)
Typing `@rev:mymod` when `mymod` isn't defined shows a one-time toast:
> *PromptRev: Unknown modifier "mymod" — falling back to default. Define it in .promptrev.json or settings.json to use it.*

## Test with F5
1. Press F5 → Extension Development Host
2. Create `.promptrev.json` in the workspace root with a custom modifier
3. Use `@rev:backend fix the auth service` — custom modifier is applied
4. Edit the file and save — changes take effect immediately without restart
5. Type `@rev:unknown prompt` — one-time info notification appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)