### PR TITLE
ci: scheduled publish workflow for npm and VS Code Marketplace

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,11 @@ jobs:
     name: Publish to npm
     runs-on: ubuntu-latest
 
+    # Required for npm Trusted Publishing (OIDC) — no NPM_TOKEN secret needed
+    permissions:
+      contents: read
+      id-token: write
+
     steps:
       - uses: actions/checkout@v4
 
@@ -46,11 +51,9 @@ jobs:
             echo "promptrev@$LOCAL is already published — skipping."
           else
             echo "Publishing promptrev@$LOCAL..."
-            cd packages/cli && npm publish
+            cd packages/cli && npm publish --provenance --access public
             echo "✅ Published promptrev@$LOCAL to npm"
           fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   # ── VS Code Marketplace ──────────────────────────────────────────────────────
   publish-vscode:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,109 @@
+name: Publish
+
+on:
+  # Run once daily at 02:00 UTC
+  schedule:
+    - cron: '0 2 * * *'
+  # Allow manual trigger from GitHub Actions UI
+  workflow_dispatch:
+
+jobs:
+  # ── npm (promptrev CLI) ──────────────────────────────────────────────────────
+  publish-npm:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build core
+        run: pnpm --filter @promptrev/core build
+
+      - name: Build CLI
+        run: pnpm --filter './packages/cli' build
+
+      - name: Check version and publish
+        run: |
+          LOCAL=$(node -p "require('./packages/cli/package.json').version")
+          PUBLISHED=$(npm show promptrev version 2>/dev/null || echo "none")
+
+          echo "Local version:     $LOCAL"
+          echo "Published version: $PUBLISHED"
+
+          if [ "$LOCAL" = "$PUBLISHED" ]; then
+            echo "promptrev@$LOCAL is already published — skipping."
+          else
+            echo "Publishing promptrev@$LOCAL..."
+            cd packages/cli && npm publish
+            echo "✅ Published promptrev@$LOCAL to npm"
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  # ── VS Code Marketplace ──────────────────────────────────────────────────────
+  publish-vscode:
+    name: Publish to VS Code Marketplace
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build core
+        run: pnpm --filter @promptrev/core build
+
+      - name: Build extension
+        run: pnpm --filter './packages/vscode' build
+
+      - name: Check version and publish
+        run: |
+          LOCAL=$(node -p "require('./packages/vscode/package.json').version")
+
+          # Fetch the currently published version from the marketplace
+          PUBLISHED=$(npx @vscode/vsce show promptrev.promptrev --json 2>/dev/null \
+            | node -e "
+                let d = '';
+                process.stdin.on('data', c => d += c);
+                process.stdin.on('end', () => {
+                  try {
+                    const p = JSON.parse(d);
+                    console.log(p.versions?.[0]?.version ?? 'none');
+                  } catch { console.log('none'); }
+                });
+              " \
+            || echo "none")
+
+          echo "Local version:     $LOCAL"
+          echo "Published version: $PUBLISHED"
+
+          if [ "$LOCAL" = "$PUBLISHED" ]; then
+            echo "PromptRev@$LOCAL is already published — skipping."
+          else
+            echo "Publishing PromptRev@$LOCAL to VS Code Marketplace..."
+            cd packages/vscode && npx @vscode/vsce publish --pat "$VSCE_PAT" --no-dependencies
+            echo "✅ Published PromptRev@$LOCAL to VS Code Marketplace"
+          fi
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}


### PR DESCRIPTION
## What this does

Adds `.github/workflows/publish.yml` — a scheduled publish pipeline that runs:
- **Daily at 02:00 UTC** (cron)
- **On-demand** via the GitHub Actions UI (`workflow_dispatch`)

Each job checks the current published version before doing anything — if it matches `package.json`, it skips. This means the workflow is safe to run frequently with zero side effects unless there's actually a new version to ship.

## Release workflow going forward

1. Bump `version` in `packages/cli/package.json` and/or `packages/vscode/package.json`
2. Merge to `main` via PR (normal flow)
3. Scheduler publishes within 24h, or hit **Run workflow** in the Actions tab to publish immediately

No manual `npm publish` or `vsce publish` commands needed.

## Required secrets (one-time setup)

| Secret | Where to get it |
|---|---|
| `NPM_TOKEN` | npmjs.com → Profile → Access Tokens → **Automation** type |
| `VSCE_PAT` | dev.azure.com → User Settings → Personal access tokens → Marketplace / Manage scope |

Add both at: **GitHub repo → Settings → Secrets and variables → Actions → New repository secret**

## Jobs

**`publish-npm`**
- Builds core + CLI
- Compares local version to `npm show promptrev version`
- Publishes if different

**`publish-vscode`**
- Builds core + extension
- Fetches published version from Marketplace via `vsce show --json`
- Publishes if different

🤖 Generated with [Claude Code](https://claude.com/claude-code)