### PR TITLE
feat: v0.7.0 — Prompt Templates

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,18 +1,10 @@
 name: Publish
 
 on:
-  # Auto-publish on merge to main when package versions change
-  push:
-    branches:
-      - main
-    paths:
-      - 'packages/cli/package.json'
-      - 'packages/vscode/package.json'
-      - 'packages/core/package.json'
-  # Nightly safety net — catches any missed version bumps
+  # Run once daily at 02:00 UTC
   schedule:
     - cron: '0 2 * * *'
-  # Keep manual trigger for emergency re-runs
+  # Allow manual trigger from GitHub Actions UI
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,10 +1,18 @@
 name: Publish
 
 on:
-  # Run once daily at 02:00 UTC
+  # Auto-publish on merge to main when package versions change
+  push:
+    branches:
+      - main
+    paths:
+      - 'packages/cli/package.json'
+      - 'packages/vscode/package.json'
+      - 'packages/core/package.json'
+  # Nightly safety net — catches any missed version bumps
   schedule:
     - cron: '0 2 * * *'
-  # Allow manual trigger from GitHub Actions UI
+  # Keep manual trigger for emergency re-runs
   workflow_dispatch:
 
 jobs:

--- a/docs/01_PRD.md
+++ b/docs/01_PRD.md
@@ -1,0 +1,267 @@
+# PromptRev — Product Requirements Document (PRD)
+
+**Version:** 0.1.0  
+**Status:** Pre-build / Design Phase  
+**Last Updated:** March 2026
+
+---
+
+## 1. Executive Summary
+
+PromptRev is a developer tool that automatically enhances, polishes, and refines prompts before they are sent to an AI agent. It works as a VS Code extension (supporting VS Code and Visual Studio), a CLI npm package, and a standalone SDK — meeting developers wherever they work. Users trigger enhancements via the `@rev` chat participant command or a global keybinding, with configurable polishing modes (modifiers) that control the depth, tone, and goal of each enhancement.
+
+---
+
+## 2. Problem Statement
+
+### 2.1 Core Pain Points
+
+**For individual developers:**
+- Writing good AI prompts is a skill that takes time to develop. Vague or poorly structured prompts produce poor results, wasting time in back-and-forth iterations.
+- Context is often missing — developers know their codebase but forget to include relevant details (language, framework, constraints) in prompts.
+- Prompts typed in flow state are often rushed — typos, incomplete thoughts, missing output format requirements.
+- There is no feedback loop between prompt quality and output quality unless the developer is already trained in prompt engineering.
+
+**For teams:**
+- Different developers produce wildly inconsistent prompt quality, leading to inconsistent AI output quality.
+- No shared standard for how to prompt the AI for a given codebase or domain.
+- Junior developers get worse results from AI tools not because the tools are worse for them, but because their prompts are weaker.
+
+**For power users:**
+- Even experienced prompt engineers have to manually apply context (tech stack, constraints, output format) to every prompt — repetitive and friction-heavy.
+- Switching between tasks (architecture thinking vs quick bug fix vs code review) requires mentally shifting prompt style — no tooling supports this.
+
+### 2.2 The Gap in Existing Solutions
+
+| Tool | What it does | What it misses |
+|---|---|---|
+| PromptDC | One-click enhancement via keyboard shortcut | No modifier system, no model reuse, limited configurability |
+| GitHub Copilot Chat | Answers prompts | Does not improve the prompts themselves |
+| Manual prompt templates | Reusable snippets | Static, not context-aware, no inline flow |
+| MCP prompt servers | Structured prompt delivery | Overhead, extra process, not inline |
+
+PromptRev fills the gap: **inline, instant, configurable prompt enhancement that reuses the model the developer already has**, with no extra infra, no API key required by default, and a modifier system that adapts to any task type.
+
+---
+
+## 3. Product Vision
+
+> **PromptRev makes every developer a prompt engineer without them needing to think about it.**
+
+The tool is deliberately invisible when you don't need it and instant when you do. It does not replace the AI — it improves what you say to the AI, in the moment, with zero workflow disruption.
+
+---
+
+## 4. Target Users
+
+| Persona | Description | Primary Need |
+|---|---|---|
+| **The Flow Developer** | Writes prompts fast and dirty, wants results without slowing down | `:fast` mode, auto-accept, instant |
+| **The Architect** | Working on system design, needs prompts that produce structured thinking | `:architect` and `:deep` modes |
+| **The Junior Dev** | Doesn't yet know how to write good prompts | Default enhancement, spell check, gentle rewrites |
+| **The Team Lead** | Wants consistent AI output across the team | Custom modifier definitions, shared config |
+| **The CLI Developer** | Works primarily in the terminal, not VS Code | npm package / CLI integration |
+
+---
+
+## 5. Features
+
+### 5.1 Core Features (v1.0)
+
+#### F1 — `@rev` Chat Participant
+- Registers as a first-class VS Code Chat Participant (`@rev`)
+- Appears in chat autocomplete natively
+- Intercepts the raw user prompt, enhances it, returns the polished version as a diff-style preview
+- Works in Copilot Chat, any VS Code chat panel that supports the Chat Participant API
+
+#### F2 — Global Keybinding
+- Default: `Cmd+Shift+E` (Mac) / `Ctrl+Shift+E` (Win/Linux)
+- Operates on selected text in any editor or chat input
+- If no text is selected, operates on the entire current input field content
+- Fully remappable in VS Code keybindings
+
+#### F3 — Modifier System
+Built-in modifiers, all user-configurable:
+
+| Modifier | Trigger | Behavior |
+|---|---|---|
+| Default | `@rev your prompt` | Grammar, clarity, structure, missing context injection |
+| `:fast` | `@rev:fast your prompt` | Minimal rewrite — sharpens and tightens only. Rule-based option for zero latency |
+| `:deep` | `@rev:deep your prompt` | Adds chain-of-thought framing, edge cases, exhaustive constraints |
+| `:architect` | `@rev:architect your prompt` | Reframes toward system design, trade-offs, scalability |
+| `:critic` | `@rev:critic your prompt` | Adds failure modes, steelman opposite approach, identify assumptions |
+| `:spell` | `@rev:spell your prompt` | Spelling and grammar only — no structural changes |
+| `:spec` | `@rev:spec your prompt` | Converts vague idea into structured spec with acceptance criteria |
+
+Users can define their own modifiers in `settings.json`.
+
+#### F4 — Accept/Reject Diff Flow
+- Enhanced prompt appears as an inline diff (original vs revised)
+- Three actions: **Accept & Send**, **Edit First**, **Dismiss**
+- Configurable per-modifier: some modes default to auto-accept (`:fast`), others default to diff (`:deep`)
+- `autoSend` flag controls whether accepted prompts are automatically sent to the LLM
+
+#### F5 — Model Reuse via `vscode.lm`
+- Uses VS Code's Language Model API to route through whatever model the user already has active (Copilot, Claude, Gemini, etc.)
+- No separate API key required by default
+- Fallback chain: `vscode.lm` → user-configured API key → local rule-based (`:fast` only)
+
+#### F6 — Prompt History Panel
+- Sidebar panel showing recent enhancement history
+- Each entry shows: original prompt, revised prompt, modifier used, timestamp
+- One-click restore of original
+- Exportable as JSON
+
+#### F7 — Spell & Prompt Quality Linting
+- Baked into every enhancement pass by default (LLM fixes typos automatically)
+- `:spell` as explicit light-touch mode (grammar/spelling only, no rewrites)
+- Optional: inline squiggles on detected vague/low-quality prompts (configurable, off by default)
+
+---
+
+### 5.2 Configuration
+
+All configuration lives in VS Code `settings.json` and an optional `.promptrev.json` project-level config file.
+
+```json
+{
+  "promptrev.acceptMode": "diff",
+  "promptrev.autoSend": false,
+  "promptrev.keepHistory": true,
+  "promptrev.defaultModifier": "default",
+  "promptrev.model": "auto",
+  "promptrev.domainContext": "React + TypeScript, Node.js backend, PostgreSQL",
+  "promptrev.modifiers": {
+    "fast": { "acceptMode": "auto", "autoSend": true },
+    "deep": { "acceptMode": "diff", "autoSend": false },
+    "mymode": {
+      "systemPrompt": "You are a prompt engineer specializing in data science tasks. Rewrite the prompt to be precise, include dataset context, and specify expected output format.",
+      "acceptMode": "diff"
+    }
+  }
+}
+```
+
+---
+
+### 5.3 Future Features (Post-v1.0)
+
+- **Team shared modifier library** — `.promptrev.json` committed to the repo, shared across all team members
+- **Prompt analytics** — track which modifiers produce the best outcomes (user-rated)
+- **Voice prompt support** — pipe voice transcripts through `@rev` before sending
+- **Custom UI panel** — dedicated sidebar with a first-class input box and button toolbar (for environments where `@rev` isn't available)
+- **JetBrains / Neovim plugin** — expand beyond VS Code
+- **`@rev` in GitHub PR comments** — polish prompts in code review contexts
+
+---
+
+## 6. Non-Goals (v1.0)
+
+- PromptRev does **not** replace the AI model — it only prepares input to it
+- PromptRev does **not** store prompts remotely or send data anywhere except the configured LLM endpoint
+- PromptRev does **not** inject a custom UI into Copilot Chat's input box (not exposed by VS Code's API)
+- PromptRev does **not** require an MCP server or any background process
+
+---
+
+## 7. Tech Stack
+
+### 7.1 VS Code Extension
+
+| Layer | Technology | Reason |
+|---|---|---|
+| Extension runtime | TypeScript | VS Code extension standard; type-safe |
+| VS Code APIs | `vscode.lm` (Language Model API), `vscode.chat` (Chat Participant API) | Native model reuse, native `@rev` participant |
+| Bundler | esbuild | Fast, minimal output, standard for VS Code extensions |
+| Testing | `@vscode/test-electron` + Mocha | Official VS Code extension testing framework |
+| Packaging | `vsce` (VS Code Extension CLI) | Marketplace publishing |
+| Visual Studio (non-Code) | VSIX packaging (same output) | VS Code and Visual Studio share VSIX format |
+
+### 7.2 npm / CLI Package
+
+| Layer | Technology | Reason |
+|---|---|---|
+| Language | TypeScript | Shared codebase with extension |
+| CLI framework | `commander` | Lightweight, widely used |
+| LLM client | `@anthropic-ai/sdk` + `openai` (optional peer deps) | User brings their own key for CLI context |
+| Build | `tsup` | Outputs both CJS and ESM; DX-friendly |
+| Package manager | npm / pnpm workspace | Monorepo shared core |
+
+### 7.3 Monorepo Structure
+
+```
+promptrev/
+├── packages/
+│   ├── core/              ← Shared enhancement logic (TypeScript)
+│   │   ├── enhancer.ts    ← Main enhancement engine
+│   │   ├── modifiers.ts   ← Modifier definitions and system prompts
+│   │   ├── diff.ts        ← Diff generation utilities
+│   │   └── history.ts     ← History management
+│   ├── vscode/            ← VS Code extension
+│   │   ├── extension.ts   ← Extension entry point
+│   │   ├── participant.ts ← @rev chat participant
+│   │   ├── keybinding.ts  ← Global keybinding handler
+│   │   └── panel.ts       ← History sidebar panel
+│   └── cli/               ← npm CLI package
+│       ├── index.ts        ← SDK exports
+│       └── bin/rev.ts      ← CLI entry point
+├── package.json            ← Workspace root
+└── tsconfig.base.json
+```
+
+### 7.4 Key Dependencies
+
+```json
+{
+  "core": {
+    "diff": "^5.0.0",
+    "zod": "^3.0.0"
+  },
+  "vscode": {
+    "@types/vscode": "^1.85.0"
+  },
+  "cli": {
+    "commander": "^12.0.0",
+    "@anthropic-ai/sdk": "^0.20.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0",
+    "esbuild": "^0.20.0",
+    "tsup": "^8.0.0",
+    "pnpm": "^9.0.0"
+  }
+}
+```
+
+### 7.5 Publishing Targets
+
+| Target | Registry | Command |
+|---|---|---|
+| VS Code Extension | VS Code Marketplace | `vsce publish` |
+| Visual Studio Extension | Visual Studio Marketplace | Same VSIX |
+| npm package (SDK) | npmjs.com | `npm publish` |
+| CLI tool | npmjs.com | `npx promptrev` or `npm i -g promptrev` |
+
+---
+
+## 8. Success Metrics
+
+| Metric | Target (3 months post-launch) |
+|---|---|
+| VS Code Marketplace installs | 1,000+ |
+| Weekly active users | 300+ |
+| Average enhancement latency | < 600ms |
+| User-rated prompt improvement | > 4/5 (in-extension feedback) |
+| Modifier usage distribution | > 3 modifiers actively used per power user |
+
+---
+
+## 9. Risks & Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| `vscode.lm` API availability varies by user setup | Fallback to user API key, then rule-based for `:fast` |
+| Enhancement latency frustrates users | Stream results, model selection defaults to Haiku/mini, `:fast` is rule-based |
+| Users don't discover modifiers | Autocomplete shows all modifiers with descriptions in chat |
+| Prompt history grows large | Local storage with configurable max entries (default 100) |
+| VS Code injects `@rev` into actual AI request | Extension intercepts and replaces before forwarding — handled by Chat Participant API design |

--- a/docs/02_USER_WORKFLOWS.md
+++ b/docs/02_USER_WORKFLOWS.md
@@ -1,0 +1,414 @@
+# PromptRev — User Workflows & Scenarios
+
+**Version:** 0.1.0  
+**Status:** Design Phase  
+**Last Updated:** March 2026
+
+---
+
+## 1. Overview
+
+This document describes real-world user workflows and scenarios for PromptRev. Each scenario includes the trigger, the step-by-step experience, and notes on configuration or behavior nuances.
+
+---
+
+## 2. Primary Workflows
+
+---
+
+### Workflow 1 — Default Enhancement via `@rev`
+
+**Persona:** Any developer using VS Code with Copilot Chat or Claude  
+**Trigger:** User types `@rev` followed by their raw prompt in chat  
+**Goal:** Get a polished, clearer version of their prompt before sending to the AI
+
+**Steps:**
+
+```
+1. User opens Copilot Chat / Claude chat in VS Code sidebar
+2. User types: @rev fix the bug in my auth module
+3. PromptRev intercepts the message (Chat Participant API)
+4. Enhancement runs (~400ms using vscode.lm)
+5. Diff preview appears in chat:
+
+   ─────────────────────────────────────────────
+   ORIGINAL:  fix the bug in my auth module
+   
+   REVISED:   Identify and fix the bug in the authentication
+              module. The module handles [JWT / session] tokens.
+              Focus on: token validation logic, error handling
+              for expired/invalid tokens, and ensure the fix
+              does not break existing auth flows. Provide a
+              brief explanation of what caused the bug.
+   ─────────────────────────────────────────────
+   [✓ Accept & Send]   [✎ Edit First]   [✗ Dismiss]
+
+6. User clicks "Accept & Send"
+7. The polished prompt is sent to the AI as if the user typed it
+```
+
+**Notes:**
+- The `@rev` prefix is stripped — the AI never sees it
+- The domain context ("JWT / session tokens") is injected from `promptrev.domainContext` in settings
+- If `autoSend: true`, step 5-6 collapses — polished prompt goes straight to AI
+
+---
+
+### Workflow 2 — Keybinding on Selected Text
+
+**Persona:** Power user who doesn't want to retype in the chat  
+**Trigger:** User selects text anywhere (editor, terminal, notes), hits `Cmd+Shift+E`  
+**Goal:** Polish a draft prompt written in the editor before copying it to chat
+
+**Steps:**
+
+```
+1. User drafts a rough prompt in any editor file:
+   "make the api faster idk maybe caching or something"
+
+2. User selects the text
+3. User presses Cmd+Shift+E (or Ctrl+Shift+E on Windows)
+
+4. A small floating diff popup appears inline:
+
+   ─────────────────────────────────────────────
+   ORIGINAL:  make the api faster idk maybe caching or something
+   
+   REVISED:   Optimize the API response time. Evaluate and
+              implement a caching strategy (e.g., Redis or
+              in-memory cache) for high-frequency endpoints.
+              Identify the current bottlenecks, suggest the
+              most appropriate caching layer, and provide
+              implementation steps with expected performance
+              impact.
+   ─────────────────────────────────────────────
+   [✓ Replace]   [✎ Edit]   [✗ Cancel]
+
+5. User clicks "Replace" — selected text is updated in place
+6. User copies the polished text and pastes into chat
+```
+
+**Notes:**
+- Works in any text context — `.md` files, `scratch.txt`, even the VS Code terminal input
+- "Replace" updates the selection in the editor; it does not send anything to the AI automatically
+
+---
+
+### Workflow 3 — Deep Mode for Architecture Thinking
+
+**Persona:** Senior developer or architect planning a system  
+**Trigger:** `@rev:deep` modifier  
+**Goal:** Transform a high-level idea into a structured, exhaustive prompt that produces thorough architectural output
+
+**Steps:**
+
+```
+1. User types: @rev:deep design a notification system for my app
+
+2. Enhancement runs with the :deep system prompt:
+   - Adds chain-of-thought instruction
+   - Prompts the AI to consider scale, edge cases, trade-offs
+   - Adds output structure requirements
+
+3. Diff preview:
+
+   REVISED:   Design a scalable notification system for the
+              application. Cover the following:
+              
+              1. Delivery channels (email, push, in-app, SMS)
+                 and when each should be used
+              2. Data model for notifications and user preferences
+              3. Queue/async architecture (consider high-volume bursts)
+              4. Retry logic and failure handling
+              5. Read/unread state management
+              6. Trade-offs between polling vs WebSockets vs SSE
+              7. Third-party services vs self-hosted considerations
+              
+              Think step by step. Call out assumptions. Flag any
+              decision points that require product input.
+
+4. User reviews, optionally edits, accepts
+```
+
+**Notes:**
+- `:deep` always defaults to `acceptMode: "diff"` — the output changes significantly and the user should review
+- Enhancement latency for `:deep` may be 600–900ms (more tokens in system prompt)
+
+---
+
+### Workflow 4 — Fast Mode for Quick Fixes
+
+**Persona:** Developer in flow state, wants zero friction  
+**Trigger:** `@rev:fast` modifier  
+**Goal:** Sharpen a prompt instantly with no review step, send immediately
+
+**Steps:**
+
+```
+1. User types: @rev:fast fix null check on user.profile
+
+2. PromptRev runs rule-based cleanup (no LLM call in fast mode):
+   - Fix grammar/spelling
+   - Remove filler words
+   - Add minimal structure
+
+3. Result (no diff shown — auto-accept):
+   "Add a null guard before accessing user.profile to prevent
+   runtime errors. Apply the fix where user.profile is first
+   accessed."
+
+4. Polished prompt is sent directly to AI (autoSend: true for :fast)
+```
+
+**Notes:**
+- `:fast` uses rule-based processing by default — truly zero latency, no API call
+- `autoSend` is `true` by default for `:fast` — the whole point is zero friction
+- User can override to use LLM for `:fast` in settings if they want higher quality
+
+---
+
+### Workflow 5 — Spell Check Only
+
+**Persona:** Non-native English speaker, or anyone who wants correction without restructuring  
+**Trigger:** `@rev:spell` modifier  
+**Goal:** Fix typos and grammar without changing the content or structure of the prompt
+
+**Steps:**
+
+```
+1. User types: @rev:spell does this endpoint handel concurrent request proprly
+
+2. LLM corrects only spelling and grammar:
+
+   REVISED:   Does this endpoint handle concurrent requests properly?
+
+3. Diff shows a minimal change — only typos fixed, no restructuring
+4. User accepts
+```
+
+**Notes:**
+- `:spell` is the most conservative modifier — it changes as little as possible
+- Useful for non-native English speakers who have already crafted the right prompt but want surface-level cleanup
+- Also good for voice-to-text workflows where transcripts have phonetic errors
+
+---
+
+### Workflow 6 — Critic Mode for Code Review Prompts
+
+**Persona:** Developer preparing a prompt for a code review or security audit task  
+**Trigger:** `@rev:critic` modifier  
+**Goal:** Reframe the prompt to produce adversarial, critical AI output
+
+**Steps:**
+
+```
+1. User types: @rev:critic review my authentication implementation
+
+2. Enhancement reframes with :critic system prompt:
+
+   REVISED:   Critically review the authentication implementation.
+              Act as a security-focused adversarial reviewer:
+              
+              - Identify security vulnerabilities (injection,
+                token leakage, session fixation, etc.)
+              - Steelman the current approach, then identify
+                where it fails
+              - Flag any assumptions the implementation makes
+                that could be wrong in production
+              - Suggest the top 3 highest-priority fixes
+              
+              Do not just describe what the code does — focus
+              on what could go wrong.
+
+3. User accepts, sends to AI for a much more rigorous review
+```
+
+---
+
+### Workflow 7 — Custom Modifier (Team-Defined)
+
+**Persona:** Team lead who has defined project-specific enhancement rules  
+**Trigger:** `@rev:backend` (custom modifier defined in `.promptrev.json`)  
+**Goal:** Auto-inject team-specific context into every prompt
+
+**`.promptrev.json` (committed to repo):**
+```json
+{
+  "modifiers": {
+    "backend": {
+      "systemPrompt": "Rewrite this prompt for a Node.js + Express backend developer working on a multi-tenant SaaS API. Always include: language (TypeScript), database (PostgreSQL + Prisma), auth method (JWT), and request that output includes error handling and input validation.",
+      "acceptMode": "diff"
+    }
+  }
+}
+```
+
+**Steps:**
+```
+1. Developer types: @rev:backend add a new endpoint for user invites
+
+2. Enhanced prompt:
+   "Create a new TypeScript/Express endpoint for sending user
+   invitations in a multi-tenant SaaS context. Use Prisma for
+   database operations (PostgreSQL). Include:
+   - JWT authentication middleware
+   - Input validation (email format, tenant scoping)
+   - Error handling (duplicate invite, invalid email, rate limiting)
+   - Return appropriate HTTP status codes
+   - Brief inline comments explaining key decisions."
+
+3. Every developer on the team gets the same quality baseline
+   without needing to know prompt engineering
+```
+
+---
+
+### Workflow 8 — CLI Usage
+
+**Persona:** Developer working in the terminal, using AI CLI tools  
+**Trigger:** `rev` CLI command  
+**Goal:** Polish a prompt before piping it to an AI CLI tool
+
+**Steps:**
+
+```bash
+# Direct enhancement
+rev "fix the race condition in my queue worker"
+
+# Output:
+# Identify and fix the race condition in the queue worker.
+# Focus on: concurrent job pickup, lock mechanisms, and
+# ensuring idempotency. Explain the root cause and the fix.
+
+# With modifier
+rev --mod deep "design a job queue"
+
+# Pipe to another tool
+rev "summarize this file" | some-ai-cli-tool
+
+# Read from file
+rev --file prompt_draft.txt --mod architect
+```
+
+**Notes:**
+- CLI reads API key from environment variable: `PROMPTREV_API_KEY` or `ANTHROPIC_API_KEY` / `OPENAI_API_KEY`
+- Modifier flag: `--mod` or `-m`
+- Output is plain text by default; `--json` flag for structured output
+
+---
+
+## 3. Edge Case Scenarios
+
+### Scenario A — No Model Available
+
+```
+User invokes @rev but has no Copilot subscription and no API key configured.
+
+Behavior:
+- PromptRev falls back to rule-based enhancement for :fast
+- For other modifiers, shows a notification:
+  "PromptRev: No language model available. Configure an API key
+  in settings or activate GitHub Copilot. [Open Settings]"
+- Original prompt is preserved unchanged
+```
+
+---
+
+### Scenario B — Very Short Prompt
+
+```
+User types: @rev help
+
+Behavior:
+- PromptRev returns the prompt unchanged with a soft notice:
+  "Prompt is too short to enhance meaningfully. Add more
+  context about what you need help with."
+- No diff shown, no API call made
+```
+
+---
+
+### Scenario C — Prompt Already Well-Structured
+
+```
+User types a prompt that is already detailed and well-formed.
+
+Behavior:
+- PromptRev returns it with minimal changes (maybe light grammar)
+- Diff shows "No significant changes needed"
+- User accepts or dismisses — no wasted processing
+```
+
+---
+
+### Scenario D — User Edits the Enhanced Prompt
+
+```
+User invokes @rev:deep, sees the enhanced version, but wants to
+adjust part of it before sending.
+
+Behavior:
+- User clicks "Edit First"
+- Enhanced prompt drops into the chat input as editable text
+- User modifies freely, then sends manually
+- History records: original → enhanced → user-edited (all three states)
+```
+
+---
+
+### Scenario E — Cancel Mid-Enhancement
+
+```
+User invokes @rev, changes their mind immediately.
+
+Behavior:
+- Escape key or "Dismiss" cancels the pending LLM call
+- Original prompt is restored exactly
+- No history entry created (cancelled before completion)
+```
+
+---
+
+## 4. Modifier Quick Reference
+
+| Modifier | Best For | Auto-send | Latency |
+|---|---|---|---|
+| `@rev` (default) | General everyday prompts | Off | ~400ms |
+| `@rev:fast` | Quick fixes, high-velocity flow | On | ~0ms (rule-based) |
+| `@rev:deep` | Architecture, complex tasks | Off | ~700ms |
+| `@rev:architect` | System design, trade-off analysis | Off | ~600ms |
+| `@rev:critic` | Code review, security audits | Off | ~500ms |
+| `@rev:spell` | Grammar/spelling only | Off | ~300ms |
+| `@rev:spec` | Converting ideas to acceptance criteria | Off | ~600ms |
+| `@rev:[custom]` | Team/project-specific rules | Configurable | Configurable |
+
+---
+
+## 5. History Panel Workflow
+
+```
+User opens PromptRev History panel in VS Code sidebar.
+
+Panel shows:
+┌─────────────────────────────────┐
+│ PROMPTREV HISTORY               │
+│                                 │
+│ ▼ 2 min ago  [@rev:deep]        │
+│   Original:  "design a cache"   │
+│   Revised:   "Design a distrib  │
+│              uted caching lay…" │
+│   [↩ Restore Original]          │
+│                                 │
+│ ▼ 8 min ago  [@rev:fast]        │
+│   Original:  "fix null check"   │
+│   Revised:   "Add null guard…"  │
+│   [↩ Restore Original]          │
+│                                 │
+│ [Export JSON]  [Clear History]  │
+└─────────────────────────────────┘
+
+Actions:
+- "Restore Original" puts the original prompt back into the chat input
+- "Export JSON" downloads full history as promptrev-history.json
+- "Clear History" with confirmation dialog
+```

--- a/docs/03_TECHNICAL_SPEC.md
+++ b/docs/03_TECHNICAL_SPEC.md
@@ -1,0 +1,686 @@
+# PromptRev — Technical Specification & Build Guide
+
+**Version:** 0.1.0  
+**Status:** Pre-build  
+**Last Updated:** March 2026
+
+---
+
+## 1. Architecture Overview
+
+PromptRev is structured as a **pnpm monorepo** with three packages:
+
+```
+promptrev/
+├── packages/
+│   ├── core/        ← Shared enhancement engine (no VS Code deps)
+│   ├── vscode/      ← VS Code/Visual Studio extension
+│   └── cli/         ← npm SDK + CLI binary
+├── pnpm-workspace.yaml
+├── package.json
+└── tsconfig.base.json
+```
+
+The `core` package contains all business logic. Both `vscode` and `cli` depend on `core` and adapt it to their environment (VS Code APIs vs Node.js/CLI).
+
+---
+
+## 2. Package: `core`
+
+### Purpose
+The enhancement engine. No runtime dependencies on VS Code or Node-specific I/O. Pure TypeScript, usable anywhere.
+
+### Key Modules
+
+#### `enhancer.ts`
+The central orchestrator. Takes a raw prompt + modifier + model adapter, returns an enhanced prompt.
+
+```typescript
+export interface EnhancerInput {
+  rawPrompt: string;
+  modifier: ModifierKey;         // 'default' | 'fast' | 'deep' | 'architect' | 'critic' | 'spell' | 'spec' | string
+  domainContext?: string;        // e.g. "React + TypeScript, Node.js"
+  modelAdapter: ModelAdapter;    // abstraction over vscode.lm or Anthropic SDK
+}
+
+export interface EnhancerOutput {
+  original: string;
+  revised: string;
+  modifier: ModifierKey;
+  timestamp: number;
+  skipped: boolean;              // true if prompt was too short / already good
+  diff: DiffChunk[];
+}
+
+export async function enhance(input: EnhancerInput): Promise<EnhancerOutput>
+```
+
+#### `modifiers.ts`
+Modifier definitions — maps modifier keys to system prompts and default config.
+
+```typescript
+export interface ModifierDefinition {
+  key: string;
+  label: string;
+  description: string;
+  systemPrompt: string;
+  acceptMode: 'diff' | 'auto';
+  autoSend: boolean;
+  useLLM: boolean;               // false = rule-based only (fast mode)
+}
+
+export const BUILT_IN_MODIFIERS: Record<string, ModifierDefinition> = {
+  default: { ... },
+  fast: { useLLM: false, acceptMode: 'auto', autoSend: true, ... },
+  deep: { useLLM: true, acceptMode: 'diff', autoSend: false, ... },
+  architect: { ... },
+  critic: { ... },
+  spell: { ... },
+  spec: { ... },
+};
+
+export function resolveModifier(
+  key: string,
+  userModifiers: Record<string, Partial<ModifierDefinition>>
+): ModifierDefinition
+```
+
+#### `model-adapter.ts`
+Abstract interface over any LLM provider. Both VS Code and CLI implement this.
+
+```typescript
+export interface ModelAdapter {
+  complete(
+    systemPrompt: string,
+    userMessage: string,
+    signal?: AbortSignal
+  ): Promise<string>;
+}
+
+// VS Code implementation (uses vscode.lm)
+export class VSCodeModelAdapter implements ModelAdapter { ... }
+
+// CLI/SDK implementation (uses Anthropic SDK or OpenAI)
+export class AnthropicModelAdapter implements ModelAdapter { ... }
+
+// Rule-based fallback (no LLM)
+export class RuleBasedAdapter implements ModelAdapter { ... }
+```
+
+#### `diff.ts`
+Diff generation between original and revised prompt.
+
+```typescript
+export interface DiffChunk {
+  type: 'equal' | 'insert' | 'delete';
+  value: string;
+}
+
+export function computeDiff(original: string, revised: string): DiffChunk[]
+export function formatDiffForDisplay(chunks: DiffChunk[]): string
+```
+
+#### `history.ts`
+In-memory + persistent history management.
+
+```typescript
+export interface HistoryEntry {
+  id: string;
+  original: string;
+  revised: string;
+  userEdited?: string;
+  modifier: string;
+  timestamp: number;
+  accepted: boolean;
+}
+
+export class HistoryManager {
+  add(entry: HistoryEntry): void
+  getAll(): HistoryEntry[]
+  restore(id: string): string       // returns original prompt
+  export(): string                   // JSON string
+  clear(): void
+}
+```
+
+#### `rule-based.ts`
+Local rule-based enhancement for `:fast` (no LLM).
+
+```typescript
+// Rules applied in order:
+// 1. Fix common spelling (levenshtein distance on known dev words)
+// 2. Remove filler phrases ("idk", "or something", "maybe", "kinda")
+// 3. Ensure ends with punctuation
+// 4. Capitalize first letter
+// 5. If missing a verb, prepend "Please"
+export function ruleBasedEnhance(raw: string): string
+```
+
+---
+
+## 3. Package: `vscode`
+
+### Purpose
+VS Code extension entry point. Registers the `@rev` Chat Participant, global keybinding, history panel, and connects everything to `core` via the VS Code Model Adapter.
+
+### Key Files
+
+#### `extension.ts` — Entry point
+
+```typescript
+import * as vscode from 'vscode';
+import { registerParticipant } from './participant';
+import { registerKeybinding } from './keybinding';
+import { HistoryPanel } from './panel';
+
+export function activate(context: vscode.ExtensionContext) {
+  registerParticipant(context);
+  registerKeybinding(context);
+  HistoryPanel.register(context);
+}
+
+export function deactivate() {}
+```
+
+#### `participant.ts` — `@rev` Chat Participant
+
+```typescript
+import * as vscode from 'vscode';
+import { enhance } from '@promptrev/core';
+import { VSCodeModelAdapter } from '@promptrev/core/model-adapter';
+import { parseModifier } from './utils';
+
+export function registerParticipant(context: vscode.ExtensionContext) {
+  const participant = vscode.chat.createChatParticipant('promptrev.rev', handler);
+  participant.iconPath = vscode.Uri.joinPath(context.extensionUri, 'icons', 'rev.png');
+  
+  // Register all modifiers as slash commands for autocomplete
+  participant.followupProvider = { ... };
+  
+  context.subscriptions.push(participant);
+}
+
+async function handler(
+  request: vscode.ChatRequest,
+  context: vscode.ChatContext,
+  stream: vscode.ChatResponseStream,
+  token: vscode.CancellationToken
+) {
+  const { modifier, rawPrompt } = parseModifier(request.prompt);
+  const config = vscode.workspace.getConfiguration('promptrev');
+  
+  const models = await vscode.lm.selectChatModels({ vendor: 'copilot' });
+  const adapter = models.length > 0 
+    ? new VSCodeModelAdapter(models[0], token) 
+    : new RuleBasedAdapter();
+
+  const result = await enhance({
+    rawPrompt,
+    modifier,
+    domainContext: config.get('domainContext'),
+    modelAdapter: adapter,
+  });
+
+  // Stream diff preview to chat
+  stream.markdown(formatDiffMarkdown(result));
+  
+  // Render action buttons
+  stream.button({ command: 'promptrev.accept', title: '✓ Accept & Send', arguments: [result] });
+  stream.button({ command: 'promptrev.edit', title: '✎ Edit First', arguments: [result] });
+  stream.button({ command: 'promptrev.dismiss', title: '✗ Dismiss', arguments: [result] });
+}
+```
+
+#### `keybinding.ts` — Global keybinding handler
+
+```typescript
+export function registerKeybinding(context: vscode.ExtensionContext) {
+  const cmd = vscode.commands.registerCommand('promptrev.enhanceSelection', async () => {
+    const editor = vscode.window.activeTextEditor;
+    const selection = editor?.selection;
+    const text = editor?.document.getText(selection) ?? '';
+    
+    if (!text.trim()) {
+      vscode.window.showInformationMessage('PromptRev: Select some text to enhance.');
+      return;
+    }
+    
+    const result = await enhance({ rawPrompt: text, modifier: 'default', ... });
+    
+    // Show inline diff
+    await showInlineDiff(editor!, selection!, result);
+  });
+  
+  context.subscriptions.push(cmd);
+}
+```
+
+#### `panel.ts` — History Sidebar Panel (WebviewViewProvider)
+
+```typescript
+export class HistoryPanel implements vscode.WebviewViewProvider {
+  resolveWebviewView(webviewView: vscode.WebviewView) {
+    webviewView.webview.html = getHistoryHTML(historyManager.getAll());
+    
+    webviewView.webview.onDidReceiveMessage(msg => {
+      if (msg.type === 'restore') { /* restore original to clipboard/editor */ }
+      if (msg.type === 'export') { /* write promptrev-history.json */ }
+      if (msg.type === 'clear') { historyManager.clear(); }
+    });
+  }
+}
+```
+
+### `package.json` Manifest (Key Sections)
+
+```json
+{
+  "name": "promptrev",
+  "displayName": "PromptRev",
+  "description": "Instantly enhance your AI prompts with @rev",
+  "version": "1.0.0",
+  "publisher": "your-publisher-id",
+  "engines": { "vscode": "^1.85.0" },
+  "categories": ["AI", "Other"],
+  "activationEvents": ["onStartupFinished"],
+  "contributes": {
+    "chatParticipants": [{
+      "id": "promptrev.rev",
+      "name": "rev",
+      "description": "Enhance your prompt before sending it to the AI",
+      "isSticky": false,
+      "commands": [
+        { "name": "fast",      "description": "Quick sharpen — auto-accept, rule-based" },
+        { "name": "deep",      "description": "Exhaustive — chain-of-thought, edge cases" },
+        { "name": "architect", "description": "System design framing" },
+        { "name": "critic",    "description": "Adversarial review framing" },
+        { "name": "spell",     "description": "Grammar and spelling only" },
+        { "name": "spec",      "description": "Convert idea to structured spec" }
+      ]
+    }],
+    "commands": [
+      {
+        "command": "promptrev.enhanceSelection",
+        "title": "PromptRev: Enhance Selected Text"
+      }
+    ],
+    "keybindings": [
+      {
+        "command": "promptrev.enhanceSelection",
+        "key": "ctrl+shift+e",
+        "mac": "cmd+shift+e"
+      }
+    ],
+    "configuration": {
+      "title": "PromptRev",
+      "properties": {
+        "promptrev.acceptMode": {
+          "type": "string",
+          "enum": ["diff", "auto", "preview"],
+          "default": "diff"
+        },
+        "promptrev.autoSend": { "type": "boolean", "default": false },
+        "promptrev.keepHistory": { "type": "boolean", "default": true },
+        "promptrev.domainContext": { "type": "string", "default": "" },
+        "promptrev.modifiers": { "type": "object", "default": {} }
+      }
+    },
+    "views": {
+      "explorer": [{
+        "type": "webview",
+        "id": "promptrev.history",
+        "name": "PromptRev History"
+      }]
+    }
+  }
+}
+```
+
+---
+
+## 4. Package: `cli`
+
+### SDK Usage
+
+```typescript
+import { enhance, modifiers } from 'promptrev';
+
+const result = await enhance({
+  rawPrompt: 'fix the race condition in my queue worker',
+  modifier: 'deep',
+  apiKey: process.env.ANTHROPIC_API_KEY,
+  domainContext: 'Node.js, Bull queue, Redis',
+});
+
+console.log(result.revised);
+```
+
+### CLI Usage
+
+```bash
+# Install globally
+npm install -g promptrev
+
+# Enhance a prompt
+rev "fix the race condition in my queue worker"
+
+# With modifier
+rev --mod deep "design a job queue system"
+
+# Pipe
+echo "fix null check" | rev --mod fast
+
+# From file
+rev --file prompt.txt --mod architect
+
+# Output as JSON
+rev --json "fix the bug" 
+
+# List available modifiers
+rev --list-modifiers
+```
+
+### CLI Entry Point (`bin/rev.ts`)
+
+```typescript
+#!/usr/bin/env node
+import { program } from 'commander';
+import { enhance } from '../index';
+
+program
+  .name('rev')
+  .description('PromptRev CLI — enhance your AI prompts')
+  .argument('[prompt]', 'Prompt to enhance')
+  .option('-m, --mod <modifier>', 'Modifier to use', 'default')
+  .option('-f, --file <path>', 'Read prompt from file')
+  .option('--json', 'Output as JSON')
+  .option('--list-modifiers', 'List available modifiers')
+  .action(async (prompt, options) => {
+    if (options.listModifiers) { /* print table */ return; }
+    
+    const raw = options.file 
+      ? fs.readFileSync(options.file, 'utf8') 
+      : prompt ?? (await readStdin());
+    
+    const result = await enhance({
+      rawPrompt: raw,
+      modifier: options.mod,
+      apiKey: process.env.PROMPTREV_API_KEY 
+           ?? process.env.ANTHROPIC_API_KEY
+           ?? process.env.OPENAI_API_KEY,
+    });
+    
+    if (options.json) {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      console.log(result.revised);
+    }
+  });
+
+program.parse();
+```
+
+---
+
+## 5. Scaffolding Steps
+
+### Step 1 — Initialize Monorepo
+
+```bash
+mkdir promptrev && cd promptrev
+pnpm init
+```
+
+`pnpm-workspace.yaml`:
+```yaml
+packages:
+  - 'packages/*'
+```
+
+`tsconfig.base.json`:
+```json
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  }
+}
+```
+
+---
+
+### Step 2 — Scaffold `core` Package
+
+```bash
+cd packages && mkdir core && cd core
+pnpm init
+pnpm add diff zod
+pnpm add -D typescript tsup @types/node
+```
+
+File structure:
+```
+packages/core/
+├── src/
+│   ├── index.ts          ← re-exports everything
+│   ├── enhancer.ts
+│   ├── modifiers.ts
+│   ├── model-adapter.ts
+│   ├── diff.ts
+│   ├── history.ts
+│   └── rule-based.ts
+├── tsup.config.ts
+└── package.json
+```
+
+`tsup.config.ts`:
+```typescript
+import { defineConfig } from 'tsup';
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  clean: true,
+});
+```
+
+**Build order:** Write and test `core` first before touching `vscode` or `cli`. The core must be model-agnostic — no `vscode` or `process.env` references.
+
+---
+
+### Step 3 — Scaffold `vscode` Extension
+
+```bash
+cd packages && npx --package yo --package generator-code yo code
+# Choose: New Extension (TypeScript)
+# Name: promptrev
+# Then override with our structure
+```
+
+Or manually:
+```bash
+mkdir vscode && cd vscode
+pnpm init
+pnpm add @promptrev/core
+pnpm add -D @types/vscode typescript esbuild @vscode/test-electron
+```
+
+Add to `package.json`:
+```json
+{
+  "main": "./dist/extension.js",
+  "scripts": {
+    "build": "esbuild src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --platform=node",
+    "watch": "npm run build -- --watch",
+    "test": "node ./test/runTest.js",
+    "package": "vsce package",
+    "publish": "vsce publish"
+  }
+}
+```
+
+`.vscodeignore`:
+```
+.vscode/**
+src/**
+node_modules/**
+*.ts
+!dist/**
+```
+
+---
+
+### Step 4 — Scaffold `cli` Package
+
+```bash
+cd packages && mkdir cli && cd cli
+pnpm init
+pnpm add @promptrev/core commander @anthropic-ai/sdk
+pnpm add -D typescript tsup @types/node
+```
+
+`package.json`:
+```json
+{
+  "name": "promptrev",
+  "bin": { "rev": "./dist/bin/rev.js" },
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  }
+}
+```
+
+---
+
+### Step 5 — System Prompt Templates
+
+These go in `core/src/modifiers.ts`. These are the actual LLM system prompts sent during enhancement:
+
+**Default modifier system prompt:**
+```
+You are a prompt engineering assistant. Your job is to rewrite the user's raw prompt 
+to be clearer, more specific, and more likely to produce a high-quality AI response.
+
+Rules:
+- Preserve the original intent exactly
+- Add missing context (specify language/framework if implied)
+- Add output format requirements if missing
+- Fix grammar and spelling
+- Remove vague filler language
+- Do not make the prompt longer than necessary
+- Return ONLY the rewritten prompt — no explanation, no preamble
+
+Domain context (if provided): {domainContext}
+```
+
+**Deep modifier system prompt:**
+```
+You are a senior prompt engineer. Rewrite this prompt to elicit an exhaustive, 
+structured, expert-level response from an AI.
+
+Add:
+- Step-by-step / chain-of-thought instruction
+- Request for edge case coverage
+- Request for trade-off analysis where relevant
+- Output structure (numbered sections, headers)
+- "Think step by step" closing instruction
+
+Return ONLY the rewritten prompt.
+```
+
+---
+
+### Step 6 — Testing Plan
+
+| Test Type | Location | Tool |
+|---|---|---|
+| Unit tests for `core` | `packages/core/tests/` | Vitest |
+| Enhancement output quality | `packages/core/tests/fixtures/` | Snapshot tests |
+| VS Code extension integration | `packages/vscode/test/` | `@vscode/test-electron` + Mocha |
+| CLI end-to-end | `packages/cli/tests/` | Vitest + execa |
+
+**Core tests to write first:**
+- `enhancer.test.ts` — given raw prompt + modifier, returns enhanced output
+- `rule-based.test.ts` — rule-based cleanup for `:fast` mode
+- `modifiers.test.ts` — modifier resolution (built-in + user-defined)
+- `diff.test.ts` — diff chunks are accurate
+
+---
+
+### Step 7 — Publishing Checklist
+
+**VS Code Marketplace:**
+```bash
+# One-time: create publisher at https://marketplace.visualstudio.com/manage
+vsce login your-publisher-id
+cd packages/vscode
+vsce package   # generates promptrev-1.0.0.vsix
+vsce publish   # publishes to marketplace
+```
+
+**npm (CLI + SDK):**
+```bash
+cd packages/cli
+npm publish --access public
+# Users can then: npx promptrev OR npm i -g promptrev
+```
+
+---
+
+## 6. Development Workflow
+
+```bash
+# Install all dependencies
+pnpm install
+
+# Build core first (others depend on it)
+pnpm --filter @promptrev/core build
+
+# Watch mode for extension development
+pnpm --filter @promptrev/vscode watch
+
+# Press F5 in VS Code to launch Extension Development Host
+
+# Run all tests
+pnpm test
+
+# Build everything for release
+pnpm -r build
+```
+
+---
+
+## 7. Environment Variables (CLI)
+
+| Variable | Purpose |
+|---|---|
+| `PROMPTREV_API_KEY` | Primary API key (Anthropic by default) |
+| `ANTHROPIC_API_KEY` | Anthropic fallback |
+| `OPENAI_API_KEY` | OpenAI fallback |
+| `PROMPTREV_MODEL` | Override model (e.g. `claude-haiku-4-20250514`) |
+| `PROMPTREV_MODIFIER` | Override default modifier |
+
+---
+
+## 8. Key Technical Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Monorepo tool | pnpm workspaces | Fast, disk-efficient, clean workspace protocol |
+| Extension bundler | esbuild | Fastest, smallest output, VS Code standard |
+| CLI bundler | tsup | Outputs CJS + ESM, DTS, minimal config |
+| LLM for VS Code | `vscode.lm` first | Zero setup for user, reuses existing model |
+| LLM for CLI | Anthropic SDK | Direct, reliable, Haiku is fast and cheap |
+| `:fast` mode | Rule-based (no LLM) | True zero latency — the whole promise of :fast |
+| Diff display | In-chat markdown | No custom UI injection needed, works natively |
+| History storage | VS Code `globalState` | Built-in, no extra dependencies, survives restarts |

--- a/docs/04_DESIGN_DECISIONS.md
+++ b/docs/04_DESIGN_DECISIONS.md
@@ -1,0 +1,188 @@
+# PromptRev — Design Decisions & Open Questions
+
+**Version:** 0.1.0  
+**Status:** Design Phase  
+**Last Updated:** March 2026
+
+---
+
+## 1. Settled Design Decisions
+
+These are decisions we've made and should not revisit without a strong reason.
+
+---
+
+### DD-01: No MCP Server
+**Decision:** PromptRev does not use or require an MCP server.  
+**Rationale:** MCP is for giving AI access to external tools/data. Prompt enhancement is a pure text transformation — it needs no external resources, no persistent connection, and no background process. An MCP server would add latency, process overhead, and cognitive load for users who already have many MCP servers enabled.  
+**Alternative considered:** MCP prompt tool with `@prompt` trigger. Rejected.
+
+---
+
+### DD-02: `@rev` as Chat Participant (not slash command, not prefix hack)
+**Decision:** Use VS Code's official Chat Participant API to register `@rev`.  
+**Rationale:** This gives native autocomplete, proper routing, clean text interception, and first-class VS Code citizenship. It's the right API for this use case.  
+**Alternative considered:** Detecting `@rev` as plain text in the input. Rejected — fragile, not native.
+
+---
+
+### DD-03: Use `vscode.lm` as the primary model in the extension
+**Decision:** The VS Code extension uses `vscode.lm` (the Language Model API) to route through whatever model the user already has active, with no separate API key required.  
+**Rationale:** Zero setup friction. The user already paid for their model. Enhancement quality improves automatically as their model improves.  
+**Fallback:** User-configured API key → rule-based (`:fast` only).
+
+---
+
+### DD-04: `:fast` mode is rule-based with no LLM call
+**Decision:** The `:fast` modifier uses local rule-based text processing — no API call.  
+**Rationale:** If someone uses `:fast`, they're signaling they want zero friction and near-zero latency. Making an LLM call defeats the purpose. The rules (remove filler, fix obvious grammar, ensure punctuation) are sufficient for the fast-path use case.  
+**Note:** Users can override this in config if they want LLM quality for `:fast`.
+
+---
+
+### DD-05: Spelling correction is baked in, not a separate pass
+**Decision:** Every enhancement pass automatically fixes spelling/grammar. `:spell` is a modifier for "spelling/grammar only, no restructuring" — not the only way to get spell checking.  
+**Rationale:** LLMs fix typos naturally during rewriting. Making it a separate step would be slower and redundant.
+
+---
+
+### DD-06: Monorepo with `core` as a shared package
+**Decision:** Business logic lives in `@promptrev/core`, which has zero VS Code or CLI dependencies. Both `vscode` and `cli` depend on `core`.  
+**Rationale:** Prevents duplication, ensures consistent enhancement behavior across both surfaces, makes testing easier (test `core` without spinning up VS Code).
+
+---
+
+### DD-07: No custom UI injection into Copilot Chat input
+**Decision:** PromptRev does not attempt to inject buttons or UI into the Copilot Chat input box.  
+**Rationale:** VS Code does not expose a public API for this. Any injection would rely on unstable DOM hacks that would break with every VS Code update.  
+**Compensating design:** The `@rev` participant + keybinding provides equivalent access points without any injection.
+
+---
+
+### DD-08: Diff shown in chat as markdown, not a separate panel
+**Decision:** The diff preview between original and revised prompt is shown directly in the chat response as formatted markdown with action buttons.  
+**Rationale:** This is the natural VS Code Chat Participant response format. It requires no custom webview for the primary flow, and keeps the user in context.  
+**Exception:** History panel is a WebviewView in the sidebar (separate from the chat diff).
+
+---
+
+### DD-09: History stored in `vscode.ExtensionContext.globalState`
+**Decision:** Prompt history is stored in VS Code's built-in `globalState` (persists across sessions, scoped to the extension).  
+**Rationale:** No extra dependencies, no file system management, survives restarts, automatically cleared with extension uninstall.  
+**Limit:** 100 entries by default, configurable.
+
+---
+
+## 2. Open Questions
+
+These require answers before or during the build phase.
+
+---
+
+### OQ-01: What happens when `autoSend: true` after acceptance?
+**Question:** When the user accepts an enhanced prompt and `autoSend` is `true`, how do we programmatically "send" the message to the AI? Does the VS Code Chat Participant API support triggering a follow-up message?  
+**Options:**
+- A: Return the enhanced prompt as a follow-up message from the participant itself (streams the enhanced prompt and passes it to the AI inline)
+- B: Write the enhanced prompt to the chat input and programmatically submit (may not be possible without private APIs)
+- C: `autoSend` is only possible when PromptRev itself is the chat surface (i.e. forward to the AI via a second `vscode.lm` call)
+
+**Recommended investigation:** Test what the Chat Participant API allows in terms of follow-up message injection.  
+**Risk level:** Medium — may affect the `autoSend` feature design significantly.
+
+---
+
+### OQ-02: How do we handle the `@rev` participant receiving a very long prompt?
+**Question:** If a user pastes a 2,000 token prompt into `@rev`, do we still send the entire thing to the polishing LLM?  
+**Options:**
+- Truncate at a configurable token limit (default: 500 tokens) and warn
+- Always send full prompt but warn about latency
+- Use a sliding window (enhance the first N tokens, leave the rest)
+
+**Decision needed before:** Building `enhancer.ts`.
+
+---
+
+### OQ-03: `vscode.lm` vendor targeting
+**Question:** `vscode.lm.selectChatModels` accepts a `vendor` filter. Should we default to `copilot`, or try to enumerate all available models?  
+**Consideration:** If the user has Claude via some other extension, targeting only `copilot` would miss it.  
+**Proposed approach:** Try `copilot` first, then fall back to `selectChatModels({})` (all vendors), then API key fallback.
+
+---
+
+### OQ-04: Modifier discovery for custom modifiers
+**Question:** If a user defines custom modifiers in `.promptrev.json`, should `@rev:[customkey]` work with autocomplete?  
+**Challenge:** VS Code Chat Participant commands are declared statically in `package.json` — they can't be dynamically registered from a project config file at runtime.  
+**Options:**
+- Static built-ins only autocomplete; custom modifiers are typed manually but still work
+- Use a `@rev:custom` command that prompts the user to pick from their defined modifiers
+- Document that custom modifiers work but don't autocomplete (acceptable for v1)
+
+---
+
+### OQ-05: Multi-language support
+**Question:** Should PromptRev enhance prompts written in languages other than English?  
+**Consideration:** Many global developers write prompts in their native language. The LLM can handle this, but the modifier system prompts are currently English-only.  
+**Proposed approach for v1:** Detect prompt language, pass it to the LLM, instruct it to preserve the input language in the output. Add explicit i18n to modifier system prompts in v2.
+
+---
+
+### OQ-06: `.promptrev.json` project config resolution
+**Question:** When the user has both `settings.json` global config and a `.promptrev.json` in the workspace root, how are they merged?  
+**Proposed merge strategy:**
+- `.promptrev.json` (project) **overrides** `settings.json` (global) for the same keys
+- Custom modifiers are **merged** (project modifiers + global modifiers, project wins on key conflict)
+- `domainContext` from `.promptrev.json` **prepends** to `settings.json` domain context
+
+---
+
+## 3. Technical Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| `vscode.lm` API changes between VS Code versions | Medium | High | Pin minimum engine version, test on multiple VS Code versions in CI |
+| Chat Participant API doesn't allow autoSend | Medium | Medium | Redesign autoSend as "copy to clipboard + open chat" fallback |
+| Enhancement latency spikes under slow models | Low | Medium | Always stream; add timeout (5s) with rule-based fallback |
+| pnpm workspace path issues on Windows | Low | Low | Test on Windows in CI from day one |
+| `vsce` VSIX packaging breaks with pnpm workspaces | Low | Medium | Use `webpack` or `esbuild` to fully bundle before packaging |
+
+---
+
+## 4. v1.0 Scope Boundary
+
+The following are explicitly **out of scope for v1.0** to keep the build focused:
+
+- Custom UI panel / input box
+- JetBrains or Neovim support
+- Team analytics or prompt rating system
+- Voice input integration
+- GitHub PR comment integration
+- Cloud sync of history or modifier libraries
+- AI-powered modifier *suggestion* (suggesting which modifier to use)
+- Diff highlighting in the actual VS Code editor (complex webview)
+
+---
+
+## 5. Naming & Branding
+
+**Package name:** `promptrev`  
+**VS Code participant:** `@rev`  
+**VS Code extension ID:** `promptrev.promptrev`  
+**npm package:** `promptrev`  
+**CLI binary:** `rev`  
+**GitHub repo:** `promptrev/promptrev` (suggested)
+
+**Publisher ID:** To be created on VS Code Marketplace. Confirm `promptrev` is available as publisher name.
+
+---
+
+## 6. Versioning Strategy
+
+| Version | Milestone |
+|---|---|
+| `0.1.0` | Core package + basic `@rev` participant (default modifier only) |
+| `0.2.0` | Full modifier system (all built-in modifiers) |
+| `0.3.0` | Keybinding + inline diff flow |
+| `0.4.0` | History panel |
+| `0.5.0` | CLI / npm package |
+| `0.6.0` | Custom user-defined modifiers |
+| `1.0.0` | Stable, published to Marketplace + npm |

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptrev",
-  "version": "0.1.0",
+  "version": "0.7.0",
   "description": "Enhance your AI prompts from the terminal",
   "keywords": ["prompt", "ai", "cli", "enhancement", "anthropic", "claude"],
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@promptrev/core",
-  "version": "0.1.0",
+  "version": "0.7.0",
   "description": "PromptRev core enhancement engine — shared logic for VS Code extension and CLI",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/core/src/__tests__/templates.test.ts
+++ b/packages/core/src/__tests__/templates.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from 'vitest';
+import {
+  BUILT_IN_TEMPLATES,
+  resolveTemplate,
+  TemplateVariableError,
+} from '../templates';
+
+describe('BUILT_IN_TEMPLATES', () => {
+  it('contains all 8 expected keys', () => {
+    const keys = Object.keys(BUILT_IN_TEMPLATES);
+    expect(keys).toContain('bug-fix');
+    expect(keys).toContain('code-review');
+    expect(keys).toContain('architecture');
+    expect(keys).toContain('refactor');
+    expect(keys).toContain('test-generation');
+    expect(keys).toContain('explain-code');
+    expect(keys).toContain('pr-description');
+    expect(keys).toContain('incident-postmortem');
+    expect(keys).toHaveLength(8);
+  });
+
+  it('each template has required fields', () => {
+    for (const tpl of Object.values(BUILT_IN_TEMPLATES)) {
+      expect(typeof tpl.key).toBe('string');
+      expect(typeof tpl.name).toBe('string');
+      expect(typeof tpl.description).toBe('string');
+      expect(Array.isArray(tpl.tags)).toBe(true);
+      expect(typeof tpl.template).toBe('string');
+      expect(Array.isArray(tpl.variables)).toBe(true);
+    }
+  });
+
+  it('all {{variable}} placeholders in template have a matching variable definition', () => {
+    for (const tpl of Object.values(BUILT_IN_TEMPLATES)) {
+      const placeholders = [...tpl.template.matchAll(/\{\{(\w+)\}\}/g)].map(
+        (m) => m[1]
+      );
+      const defined = tpl.variables.map((v) => v.name);
+      for (const p of placeholders) {
+        expect(defined).toContain(p);
+      }
+    }
+  });
+});
+
+describe('resolveTemplate — variable substitution', () => {
+  it('fills all required and optional variables', () => {
+    const result = resolveTemplate('bug-fix', {
+      bug_type: 'null pointer',
+      file_or_module: 'src/auth/token.ts',
+      context: 'happens on login',
+      language: 'TypeScript',
+      expected: 'returns 401',
+      actual: 'throws exception',
+    });
+    expect(result).toContain('null pointer');
+    expect(result).toContain('src/auth/token.ts');
+    expect(result).toContain('happens on login');
+    expect(result).toContain('TypeScript');
+    expect(result).toContain('returns 401');
+    expect(result).toContain('throws exception');
+    // No remaining placeholders
+    expect(result).not.toMatch(/\{\{\w+\}\}/);
+  });
+
+  it('replaces optional missing variables with empty string', () => {
+    const result = resolveTemplate('bug-fix', {
+      bug_type: 'race condition',
+      file_or_module: 'src/queue.ts',
+      expected: 'processes once',
+      actual: 'processes twice',
+      // context and language omitted
+    });
+    expect(result).not.toMatch(/\{\{\w+\}\}/);
+    expect(result).toContain('race condition');
+  });
+});
+
+describe('resolveTemplate — required variable enforcement', () => {
+  it('throws TemplateVariableError when a required variable is missing', () => {
+    expect(() =>
+      resolveTemplate('bug-fix', {
+        // bug_type is required but omitted
+        file_or_module: 'src/auth/token.ts',
+        expected: 'returns 401',
+        actual: 'throws exception',
+      })
+    ).toThrow(TemplateVariableError);
+  });
+
+  it('error message names the missing variables', () => {
+    let caught: TemplateVariableError | null = null;
+    try {
+      resolveTemplate('bug-fix', {
+        file_or_module: 'src/auth/token.ts',
+        // bug_type, expected, actual all missing
+      });
+    } catch (e) {
+      caught = e as TemplateVariableError;
+    }
+    expect(caught).not.toBeNull();
+    expect(caught!.missingVariables).toContain('bug_type');
+    expect(caught!.missingVariables).toContain('expected');
+    expect(caught!.missingVariables).toContain('actual');
+    expect(caught!.templateKey).toBe('bug-fix');
+  });
+
+  it('does not throw when only optional variables are missing', () => {
+    expect(() =>
+      resolveTemplate('code-review', {
+        file_or_module: 'src/auth/token.ts',
+        // language, scope, focus all optional
+      })
+    ).not.toThrow();
+  });
+});
+
+describe('resolveTemplate — unknown key fallback', () => {
+  it('returns a best-effort prompt from variables for unknown key', () => {
+    const result = resolveTemplate('nonexistent-key', {
+      thing: 'value1',
+      other: 'value2',
+    });
+    expect(result).toContain('value1');
+    expect(result).toContain('value2');
+  });
+
+  it('returns key as fallback when variables are empty', () => {
+    const result = resolveTemplate('nonexistent-key', {});
+    expect(result).toBe('nonexistent-key');
+  });
+});
+
+describe('resolveTemplate — user override', () => {
+  it('user template overrides built-in on same key', () => {
+    const result = resolveTemplate(
+      'bug-fix',
+      {
+        bug_type: 'race condition',
+        file_or_module: 'src/queue.ts',
+        expected: 'once',
+        actual: 'twice',
+      },
+      {
+        'bug-fix': {
+          template: 'Custom: {{bug_type}} in {{file_or_module}}. Expected: {{expected}}. Actual: {{actual}}.',
+        },
+      }
+    );
+    expect(result).toMatch(/^Custom:/);
+    expect(result).toContain('race condition');
+  });
+
+  it('user-defined template with unknown key works if template is provided', () => {
+    const result = resolveTemplate(
+      'my-template',
+      { topic: 'authentication' },
+      {
+        'my-template': {
+          name: 'My Template',
+          template: 'Explain {{topic}} in depth.',
+          variables: [
+            { name: 'topic', description: 'Topic', placeholder: 'auth', required: true },
+          ],
+        },
+      }
+    );
+    expect(result).toBe('Explain authentication in depth.');
+  });
+
+  it('unknown user template without template string falls back gracefully', () => {
+    const result = resolveTemplate(
+      'no-template-key',
+      { a: 'hello' },
+      { 'no-template-key': { name: 'No template', description: 'test' } }
+    );
+    expect(result).toContain('hello');
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,3 +20,7 @@ export type { HistoryEntry, HistoryStorage } from './history';
 
 // Rule-based enhancement
 export { ruleBasedEnhance } from './rule-based';
+
+// Prompt templates
+export { BUILT_IN_TEMPLATES, resolveTemplate, TemplateVariableError } from './templates';
+export type { PromptTemplate, TemplateVariable } from './templates';

--- a/packages/core/src/templates.ts
+++ b/packages/core/src/templates.ts
@@ -1,0 +1,518 @@
+export interface TemplateVariable {
+  name: string;
+  description: string;
+  placeholder: string;
+  required: boolean;
+}
+
+export interface PromptTemplate {
+  key: string;
+  name: string;
+  description: string;
+  tags: string[];
+  /** Raw string with {{variable}} placeholders */
+  template: string;
+  variables: TemplateVariable[];
+  /** Suggested modifier key, e.g. 'critic' for code-review */
+  suggestedModifier?: string;
+}
+
+export class TemplateVariableError extends Error {
+  constructor(
+    public readonly templateKey: string,
+    public readonly missingVariables: string[]
+  ) {
+    super(
+      `Template "${templateKey}" is missing required variables: ${missingVariables.join(', ')}`
+    );
+    this.name = 'TemplateVariableError';
+  }
+}
+
+// ─── Built-in templates ───────────────────────────────────────────────────────
+
+export const BUILT_IN_TEMPLATES: Record<string, PromptTemplate> = {
+  'bug-fix': {
+    key: 'bug-fix',
+    name: 'Bug Fix',
+    description: 'Structured prompt for debugging and fixing a specific issue',
+    tags: ['debugging', 'code'],
+    suggestedModifier: 'default',
+    template: `Identify and fix the {{bug_type}} bug in {{file_or_module}}.
+
+Context: {{context}}
+Language / framework: {{language}}
+
+Expected behaviour: {{expected}}
+Actual behaviour: {{actual}}
+
+Provide:
+1. Root cause analysis
+2. The fix with code
+3. A regression test to prevent recurrence`,
+    variables: [
+      {
+        name: 'bug_type',
+        description: 'Type of bug',
+        placeholder: 'null pointer / race condition / off-by-one',
+        required: true,
+      },
+      {
+        name: 'file_or_module',
+        description: 'File or module affected',
+        placeholder: 'auth/token.ts',
+        required: true,
+      },
+      {
+        name: 'context',
+        description: 'Relevant background',
+        placeholder: 'happens on login with expired token',
+        required: false,
+      },
+      {
+        name: 'language',
+        description: 'Language / framework',
+        placeholder: 'TypeScript, Express',
+        required: false,
+      },
+      {
+        name: 'expected',
+        description: 'Expected behaviour',
+        placeholder: 'returns 401',
+        required: true,
+      },
+      {
+        name: 'actual',
+        description: 'Actual behaviour',
+        placeholder: 'throws unhandled exception',
+        required: true,
+      },
+    ],
+  },
+
+  'code-review': {
+    key: 'code-review',
+    name: 'Code Review',
+    description: 'Structured review with scope and focus areas',
+    tags: ['review', 'code quality'],
+    suggestedModifier: 'critic',
+    template: `Review the following {{language}} code in {{file_or_module}}.
+
+Scope: {{scope}}
+Focus areas: {{focus}}
+
+For each issue found, provide:
+1. Severity (critical / major / minor)
+2. Description of the problem
+3. Suggested fix with code example
+
+Also note any positives worth preserving.`,
+    variables: [
+      {
+        name: 'language',
+        description: 'Language / framework',
+        placeholder: 'TypeScript',
+        required: false,
+      },
+      {
+        name: 'file_or_module',
+        description: 'File or module to review',
+        placeholder: 'src/auth/token.ts',
+        required: true,
+      },
+      {
+        name: 'scope',
+        description: 'What to focus on',
+        placeholder: 'the token refresh logic',
+        required: false,
+      },
+      {
+        name: 'focus',
+        description: 'Specific concerns',
+        placeholder: 'security, error handling, performance',
+        required: false,
+      },
+    ],
+  },
+
+  architecture: {
+    key: 'architecture',
+    name: 'Architecture Design',
+    description: 'System design with constraints and trade-offs',
+    tags: ['architecture', 'system design'],
+    suggestedModifier: 'architect',
+    template: `Design the architecture for {{system}}.
+
+Requirements:
+- {{requirements}}
+
+Constraints: {{constraints}}
+Scale: {{scale}}
+
+Cover:
+1. High-level component diagram (described in text)
+2. Data flow between components
+3. Key trade-offs and the chosen approach
+4. Technology choices with rationale
+5. Open questions that need resolution`,
+    variables: [
+      {
+        name: 'system',
+        description: 'System or feature to design',
+        placeholder: 'a real-time notification system',
+        required: true,
+      },
+      {
+        name: 'requirements',
+        description: 'Functional requirements',
+        placeholder: 'push to web and mobile, support 10k concurrent users',
+        required: true,
+      },
+      {
+        name: 'constraints',
+        description: 'Technical or business constraints',
+        placeholder: 'existing AWS infrastructure, no new databases',
+        required: false,
+      },
+      {
+        name: 'scale',
+        description: 'Expected scale',
+        placeholder: '100k users, 1M events/day',
+        required: false,
+      },
+    ],
+  },
+
+  refactor: {
+    key: 'refactor',
+    name: 'Refactor',
+    description: 'Targeted refactor with clear goals and constraints',
+    tags: ['refactor', 'code quality'],
+    suggestedModifier: 'deep',
+    template: `Refactor {{file_or_module}} to {{goal}}.
+
+Current problem: {{problem}}
+Language / framework: {{language}}
+
+Constraints:
+- Preserve all existing behaviour (no functional changes)
+- {{constraints}}
+
+Provide:
+1. Refactored code
+2. Explanation of each change
+3. Any risks or caveats`,
+    variables: [
+      {
+        name: 'file_or_module',
+        description: 'File or module to refactor',
+        placeholder: 'src/utils/date-helpers.ts',
+        required: true,
+      },
+      {
+        name: 'goal',
+        description: 'Refactoring goal',
+        placeholder: 'improve readability and remove duplication',
+        required: true,
+      },
+      {
+        name: 'problem',
+        description: 'What is wrong currently',
+        placeholder: 'deeply nested conditionals, repeated date parsing logic',
+        required: false,
+      },
+      {
+        name: 'language',
+        description: 'Language / framework',
+        placeholder: 'TypeScript',
+        required: false,
+      },
+      {
+        name: 'constraints',
+        description: 'Additional constraints',
+        placeholder: 'no new dependencies',
+        required: false,
+      },
+    ],
+  },
+
+  'test-generation': {
+    key: 'test-generation',
+    name: 'Test Generation',
+    description: 'Tests with coverage goals and edge cases',
+    tags: ['testing', 'code quality'],
+    suggestedModifier: 'spec',
+    template: `Write {{test_type}} tests for {{file_or_module}}.
+
+Function / feature under test: {{target}}
+Language / framework: {{language}}
+Test framework: {{test_framework}}
+
+Coverage goals:
+- {{coverage_goals}}
+
+Include edge cases for: {{edge_cases}}`,
+    variables: [
+      {
+        name: 'test_type',
+        description: 'Type of tests',
+        placeholder: 'unit',
+        required: true,
+      },
+      {
+        name: 'file_or_module',
+        description: 'File or module to test',
+        placeholder: 'src/auth/token.ts',
+        required: true,
+      },
+      {
+        name: 'target',
+        description: 'Specific function or feature',
+        placeholder: 'validateToken()',
+        required: false,
+      },
+      {
+        name: 'language',
+        description: 'Language / framework',
+        placeholder: 'TypeScript, Node.js',
+        required: false,
+      },
+      {
+        name: 'test_framework',
+        description: 'Test framework',
+        placeholder: 'Vitest',
+        required: false,
+      },
+      {
+        name: 'coverage_goals',
+        description: 'Coverage goals',
+        placeholder: 'happy path, expired token, malformed token',
+        required: false,
+      },
+      {
+        name: 'edge_cases',
+        description: 'Edge cases to cover',
+        placeholder: 'null input, empty string, unicode characters',
+        required: false,
+      },
+    ],
+  },
+
+  'explain-code': {
+    key: 'explain-code',
+    name: 'Explain Code',
+    description: 'Code explanation at a specific audience level',
+    tags: ['explanation', 'documentation'],
+    suggestedModifier: 'default',
+    template: `Explain the following {{language}} code in {{file_or_module}}.
+
+Target audience: {{audience}}
+Focus: {{focus}}
+
+{{code}}
+
+Cover:
+1. What it does (high-level)
+2. How it works (step-by-step)
+3. Why it is designed this way (if notable)
+4. Any gotchas or non-obvious behaviour`,
+    variables: [
+      {
+        name: 'language',
+        description: 'Language / framework',
+        placeholder: 'TypeScript',
+        required: false,
+      },
+      {
+        name: 'file_or_module',
+        description: 'File or module',
+        placeholder: 'src/queue/worker.ts',
+        required: false,
+      },
+      {
+        name: 'audience',
+        description: 'Who this explanation is for',
+        placeholder: 'a junior developer unfamiliar with queues',
+        required: false,
+      },
+      {
+        name: 'focus',
+        description: 'What to emphasise',
+        placeholder: 'the retry logic and backoff strategy',
+        required: false,
+      },
+      {
+        name: 'code',
+        description: 'The code to explain (paste here or describe it)',
+        placeholder: '(paste code here)',
+        required: true,
+      },
+    ],
+  },
+
+  'pr-description': {
+    key: 'pr-description',
+    name: 'PR Description',
+    description: 'PR title, summary, and test plan from code changes',
+    tags: ['git', 'documentation'],
+    suggestedModifier: 'spec',
+    template: `Write a pull request description for the following change.
+
+Change summary: {{summary}}
+Files changed: {{files}}
+Motivation: {{motivation}}
+
+Format:
+## Summary
+(2–4 bullet points of what changed)
+
+## Why
+(Business or technical motivation)
+
+## Test plan
+(Checklist of how to verify the change)
+
+## Notes
+(Any deployment concerns, follow-ups, or caveats)`,
+    variables: [
+      {
+        name: 'summary',
+        description: 'What the PR does',
+        placeholder: 'adds rate limiting to the /auth/login endpoint',
+        required: true,
+      },
+      {
+        name: 'files',
+        description: 'Key files changed',
+        placeholder: 'src/auth/login.ts, src/middleware/rate-limit.ts',
+        required: false,
+      },
+      {
+        name: 'motivation',
+        description: 'Why this change is needed',
+        placeholder: 'prevent brute force attacks flagged in security review',
+        required: false,
+      },
+    ],
+  },
+
+  'incident-postmortem': {
+    key: 'incident-postmortem',
+    name: 'Incident Postmortem',
+    description: 'Post-incident analysis with timeline and action items',
+    tags: ['ops', 'incident management'],
+    suggestedModifier: 'deep',
+    template: `Write an incident postmortem for the following outage.
+
+Service: {{service}}
+Duration: {{duration}}
+Severity: {{severity}}
+Impact: {{impact}}
+Timeline: {{timeline}}
+
+Include:
+1. Executive summary (2–3 sentences)
+2. Timeline of events
+3. Root cause (primary + contributing factors)
+4. What went well
+5. What went wrong
+6. Action items with owners and due dates`,
+    variables: [
+      {
+        name: 'service',
+        description: 'Affected service',
+        placeholder: 'payments-api',
+        required: true,
+      },
+      {
+        name: 'duration',
+        description: 'Outage duration',
+        placeholder: '47 minutes',
+        required: true,
+      },
+      {
+        name: 'severity',
+        description: 'Severity level',
+        placeholder: 'SEV-2',
+        required: false,
+      },
+      {
+        name: 'impact',
+        description: 'User / business impact',
+        placeholder: 'checkout unavailable for EU users, ~$12k revenue impact',
+        required: true,
+      },
+      {
+        name: 'timeline',
+        description: 'Key events with timestamps',
+        placeholder: '14:02 alert fired, 14:23 root cause identified, 14:49 fix deployed',
+        required: false,
+      },
+    ],
+  },
+};
+
+// ─── resolveTemplate ──────────────────────────────────────────────────────────
+
+/**
+ * Fills a template's {{variable}} placeholders with the provided values.
+ *
+ * - Missing required variables throw `TemplateVariableError`
+ * - Missing optional variables are replaced with empty string
+ * - Unknown template key falls back to returning the raw variables as a plain prompt
+ * - User-defined templates in `userTemplates` override built-ins on key conflict
+ */
+export function resolveTemplate(
+  key: string,
+  variables: Record<string, string>,
+  userTemplates: Record<string, Partial<PromptTemplate>> = {}
+): string {
+  // Merge: user templates win over built-ins
+  const builtIn = BUILT_IN_TEMPLATES[key];
+  const userDefined = userTemplates[key];
+
+  let tpl: PromptTemplate | undefined;
+
+  if (builtIn && userDefined) {
+    tpl = { ...builtIn, ...userDefined } as PromptTemplate;
+  } else if (builtIn) {
+    tpl = builtIn;
+  } else if (userDefined && userDefined.template) {
+    tpl = {
+      key,
+      name: userDefined.name ?? key,
+      description: userDefined.description ?? `Custom template: ${key}`,
+      tags: userDefined.tags ?? [],
+      template: userDefined.template,
+      variables: userDefined.variables ?? [],
+      suggestedModifier: userDefined.suggestedModifier,
+    };
+  }
+
+  if (!tpl) {
+    // Unknown key — compose a best-effort prompt from variables
+    const entries = Object.entries(variables)
+      .filter(([, v]) => v.trim())
+      .map(([k, v]) => `${k}: ${v}`)
+      .join('\n');
+    return entries || key;
+  }
+
+  // Validate required variables
+  const missing = tpl.variables
+    .filter((v) => v.required && !variables[v.name]?.trim())
+    .map((v) => v.name);
+
+  if (missing.length > 0) {
+    throw new TemplateVariableError(key, missing);
+  }
+
+  // Replace all {{variable}} occurrences
+  let filled = tpl.template;
+  for (const variable of tpl.variables) {
+    const value = variables[variable.name]?.trim() ?? '';
+    filled = filled.split(`{{${variable.name}}}`).join(value);
+  }
+
+  return filled;
+}

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "promptrev",
   "displayName": "PromptRev",
   "description": "Instantly enhance your AI prompts with @rev",
-  "version": "0.1.0",
+  "version": "0.7.0",
   "publisher": "promptrev",
   "repository": {
     "type": "git",
@@ -54,6 +54,42 @@
           {
             "name": "spec",
             "description": "Convert idea to structured spec with acceptance criteria"
+          },
+          {
+            "name": "template",
+            "description": "Browse and fill a prompt template"
+          },
+          {
+            "name": "bug-fix",
+            "description": "Template: structured debugging prompt with root cause + fix + regression test"
+          },
+          {
+            "name": "code-review",
+            "description": "Template: structured code review with severity ratings and suggested fixes"
+          },
+          {
+            "name": "architecture",
+            "description": "Template: system design with requirements, constraints, and trade-offs"
+          },
+          {
+            "name": "refactor",
+            "description": "Template: targeted refactor with goals, constraints, and risk notes"
+          },
+          {
+            "name": "test-generation",
+            "description": "Template: test generation with coverage goals and edge cases"
+          },
+          {
+            "name": "explain-code",
+            "description": "Template: code explanation at a specified audience level"
+          },
+          {
+            "name": "pr-description",
+            "description": "Template: PR title, summary, and test plan from code changes"
+          },
+          {
+            "name": "incident-postmortem",
+            "description": "Template: incident postmortem with timeline, root cause, and action items"
           }
         ]
       }
@@ -82,6 +118,10 @@
       {
         "command": "promptrev.dismiss",
         "title": "PromptRev: Dismiss Enhancement"
+      },
+      {
+        "command": "promptrev.openTemplatePicker",
+        "title": "PromptRev: Browse Templates"
       }
     ],
     "keybindings": [
@@ -90,6 +130,11 @@
         "key": "ctrl+shift+e",
         "mac": "cmd+shift+e",
         "when": "editorTextFocus"
+      },
+      {
+        "command": "promptrev.openTemplatePicker",
+        "key": "ctrl+shift+t",
+        "mac": "cmd+shift+t"
       }
     ],
     "configuration": {
@@ -137,6 +182,11 @@
           "type": "object",
           "default": {},
           "description": "Custom modifier definitions or overrides for built-in modifiers"
+        },
+        "promptrev.templates": {
+          "type": "object",
+          "default": {},
+          "description": "Custom template definitions. Each key is a template identifier; each value is a PromptTemplate object with name, description, template string, and variables array."
         }
       }
     },

--- a/packages/vscode/src/commands.ts
+++ b/packages/vscode/src/commands.ts
@@ -16,10 +16,18 @@ function consumeResult(timestamp: number): EnhancerOutput | undefined {
   return result;
 }
 
-export function registerCommands(context: vscode.ExtensionContext, _historyPanel: HistoryPanelProvider): void {
+export function registerCommands(
+  context: vscode.ExtensionContext,
+  _historyPanel: HistoryPanelProvider,
+  openTemplatePicker: () => Promise<void>
+): void {
   context.subscriptions.push(
     vscode.commands.registerCommand('promptrev.openHistory', () => {
       void vscode.commands.executeCommand('promptrev.history.focus');
+    }),
+
+    vscode.commands.registerCommand('promptrev.openTemplatePicker', () => {
+      void openTemplatePicker();
     }),
 
     vscode.commands.registerCommand('promptrev.accept', async (timestamp?: number) => {

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -5,6 +5,7 @@ import { registerCommands } from './commands';
 import { initHistoryManager } from './history-manager';
 import { HistoryPanelProvider } from './history-panel';
 import { ProjectConfigProvider } from './project-config';
+import { openTemplatePickerCommand } from './template-picker';
 
 export function activate(context: vscode.ExtensionContext): void {
   initHistoryManager(context);
@@ -19,7 +20,9 @@ export function activate(context: vscode.ExtensionContext): void {
   // Load .promptrev.json asynchronously — participant/keybinding read it on each invocation
   void projectConfig.init();
 
-  registerCommands(context, historyPanel);
+  registerCommands(context, historyPanel, () =>
+    openTemplatePickerCommand(historyPanel, projectConfig)
+  );
   registerParticipant(context, historyPanel, projectConfig);
   registerKeybinding(context, historyPanel, projectConfig);
 }

--- a/packages/vscode/src/participant.ts
+++ b/packages/vscode/src/participant.ts
@@ -1,11 +1,12 @@
 import * as vscode from 'vscode';
-import { enhance, RuleBasedAdapter, resolveModifier, formatDiffMarkdown } from '@promptrev/core';
+import { enhance, RuleBasedAdapter, resolveModifier, formatDiffMarkdown, BUILT_IN_TEMPLATES } from '@promptrev/core';
 import type { EnhancerOutput } from '@promptrev/core';
 import { VSCodeModelAdapter } from './vscode-model-adapter';
 import { parseModifierFromCommand } from './utils';
 import { selectModel, handleNoModel } from './model-selector';
 import { addPendingResult } from './commands';
 import { getHistoryManager } from './history-manager';
+import { runTemplateFlow } from './template-picker';
 import type { HistoryPanelProvider } from './history-panel';
 import type { ProjectConfigProvider } from './project-config';
 
@@ -32,7 +33,29 @@ async function handler(
   historyPanel: HistoryPanelProvider,
   projectConfig: ProjectConfigProvider
 ): Promise<void> {
-  const modifier = parseModifierFromCommand(request.command);
+  const command = request.command;
+
+  // ── Template flow: @rev /template or @rev /bug-fix etc. ──────────────────
+  const isTemplateCommand =
+    command === 'template' ||
+    (command !== undefined && command in BUILT_IN_TEMPLATES) ||
+    projectConfig.isKnownTemplate(command ?? '');
+
+  if (isTemplateCommand) {
+    // 'template' with no pre-selection → open picker
+    // any other template key → go straight to variable input
+    await runTemplateFlow(
+      stream,
+      token,
+      historyPanel,
+      projectConfig,
+      command !== 'template' ? command : undefined
+    );
+    return;
+  }
+
+  // ── Modifier flow (existing behaviour) ────────────────────────────────────
+  const modifier = parseModifierFromCommand(command);
   const rawPrompt = request.prompt.trim();
 
   if (!rawPrompt) {

--- a/packages/vscode/src/project-config.ts
+++ b/packages/vscode/src/project-config.ts
@@ -1,10 +1,19 @@
 import * as vscode from 'vscode';
-import { BUILT_IN_MODIFIERS } from '@promptrev/core';
-import type { ModifierDefinition } from '@promptrev/core';
+import { BUILT_IN_MODIFIERS, BUILT_IN_TEMPLATES } from '@promptrev/core';
+import type { ModifierDefinition, PromptTemplate } from '@promptrev/core';
 
 export interface ProjectConfig {
   domainContext?: string;
   modifiers?: Record<string, Partial<ModifierDefinition>>;
+  templates?: Record<string, Partial<PromptTemplate>>;
+}
+
+/** Source label shown in the template Quick Pick */
+export type TemplateSource = 'built-in' | 'user' | 'team';
+
+export interface MergedTemplate {
+  template: PromptTemplate;
+  source: TemplateSource;
 }
 
 const CONFIG_FILENAME = '.promptrev.json';
@@ -66,6 +75,101 @@ export class ProjectConfigProvider {
     return key in BUILT_IN_MODIFIERS || key in this.getMergedModifiers();
   }
 
+  /**
+   * Returns true if the key is a known template (built-in or user/team defined).
+   */
+  isKnownTemplate(key: string): boolean {
+    return key in BUILT_IN_TEMPLATES || key in this.getMergedRawTemplates();
+  }
+
+  /**
+   * Returns user+team templates merged (no built-ins).
+   * Used internally for merge operations.
+   */
+  getMergedRawTemplates(): Record<string, Partial<PromptTemplate>> {
+    const userSettings = vscode.workspace
+      .getConfiguration('promptrev')
+      .get<Record<string, Partial<PromptTemplate>>>('templates') ?? {};
+    return { ...userSettings, ...this._config.templates };
+  }
+
+  /**
+   * Returns all templates — built-ins, then user settings, then project templates.
+   * Annotated with their source for display in the picker.
+   *
+   * Merge precedence (highest → lowest):
+   *   .promptrev.json  >  settings.json (promptrev.templates)  >  built-ins
+   */
+  getMergedTemplates(): MergedTemplate[] {
+    const userSettings = vscode.workspace
+      .getConfiguration('promptrev')
+      .get<Record<string, Partial<PromptTemplate>>>('templates') ?? {};
+    const projectTemplates = this._config.templates ?? {};
+
+    const result: MergedTemplate[] = [];
+    const seen = new Set<string>();
+
+    // Built-ins first (may be overridden by later layers)
+    for (const [key, tpl] of Object.entries(BUILT_IN_TEMPLATES)) {
+      const merged: PromptTemplate = {
+        ...tpl,
+        ...(userSettings[key] ?? {}),
+        ...(projectTemplates[key] ?? {}),
+      } as PromptTemplate;
+
+      // Determine effective source (overridden built-ins still show as built-in
+      // unless only user/team defined)
+      const source: TemplateSource = projectTemplates[key]
+        ? 'team'
+        : userSettings[key]
+        ? 'user'
+        : 'built-in';
+
+      result.push({ template: merged, source });
+      seen.add(key);
+    }
+
+    // User-defined (not overriding a built-in)
+    for (const [key, partial] of Object.entries(userSettings)) {
+      if (seen.has(key)) continue;
+      if (!partial.template) continue; // skip incomplete user definitions
+      result.push({
+        template: {
+          key,
+          name: partial.name ?? key,
+          description: partial.description ?? `Custom template: ${key}`,
+          tags: partial.tags ?? [],
+          template: partial.template,
+          variables: partial.variables ?? [],
+          suggestedModifier: partial.suggestedModifier,
+        },
+        source: 'user',
+      });
+      seen.add(key);
+    }
+
+    // Project / team templates (not overriding anything already seen)
+    for (const [key, partial] of Object.entries(projectTemplates)) {
+      if (seen.has(key)) continue;
+      if (!partial.template) continue;
+      result.push({
+        template: {
+          key,
+          name: partial.name ?? key,
+          description: partial.description ?? `Team template: ${key}`,
+          tags: partial.tags ?? [],
+          template: partial.template,
+          variables: partial.variables ?? [],
+          suggestedModifier: partial.suggestedModifier,
+        },
+        source: 'team',
+      });
+      seen.add(key);
+    }
+
+    return result;
+  }
+
   private async _reload(): Promise<void> {
     const folder = vscode.workspace.workspaceFolders?.[0];
     if (!folder) {
@@ -105,6 +209,10 @@ export class ProjectConfigProvider {
 
     if (typeof obj.modifiers === 'object' && obj.modifiers !== null && !Array.isArray(obj.modifiers)) {
       result.modifiers = obj.modifiers as Record<string, Partial<ModifierDefinition>>;
+    }
+
+    if (typeof obj.templates === 'object' && obj.templates !== null && !Array.isArray(obj.templates)) {
+      result.templates = obj.templates as Record<string, Partial<PromptTemplate>>;
     }
 
     return result;

--- a/packages/vscode/src/template-picker.ts
+++ b/packages/vscode/src/template-picker.ts
@@ -1,0 +1,425 @@
+import * as vscode from 'vscode';
+import {
+  enhance,
+  resolveTemplate,
+  TemplateVariableError,
+  RuleBasedAdapter,
+  BUILT_IN_MODIFIERS,
+} from '@promptrev/core';
+import type { PromptTemplate, EnhancerOutput } from '@promptrev/core';
+import { VSCodeModelAdapter } from './vscode-model-adapter';
+import { selectModel } from './model-selector';
+import { addPendingResult } from './commands';
+import { getHistoryManager } from './history-manager';
+import { formatDiffMarkdown } from '@promptrev/core';
+import type { HistoryPanelProvider } from './history-panel';
+import type { ProjectConfigProvider, MergedTemplate } from './project-config';
+
+const SOURCE_LABEL: Record<string, string> = {
+  'built-in': '$(tools) Built-in',
+  user: '$(person) Your templates',
+  team: '$(organization) Team (.promptrev.json)',
+};
+
+const SOURCE_ICON: Record<string, string> = {
+  'built-in': '$(tools)',
+  user: '$(person)',
+  team: '$(organization)',
+};
+
+interface TemplateQuickPickItem extends vscode.QuickPickItem {
+  templateKey: string;
+}
+
+/**
+ * Opens the template Quick Pick, collects variable values, optionally applies
+ * a modifier, then calls enhance() and renders the result into `stream`.
+ *
+ * Used from the @rev /template command (and template sub-commands like /bug-fix).
+ */
+export async function runTemplateFlow(
+  stream: vscode.ChatResponseStream,
+  token: vscode.CancellationToken,
+  historyPanel: HistoryPanelProvider,
+  projectConfig: ProjectConfigProvider,
+  preSelectedKey?: string
+): Promise<void> {
+  const mergedTemplates = projectConfig.getMergedTemplates();
+  const userTemplates = projectConfig.getMergedRawTemplates();
+
+  // ── Step 1: pick a template (or use pre-selected) ────────────────────────
+  let selectedTemplate: PromptTemplate | undefined;
+
+  if (preSelectedKey) {
+    const found = mergedTemplates.find((m) => m.template.key === preSelectedKey);
+    selectedTemplate = found?.template;
+    if (!selectedTemplate) {
+      stream.markdown(
+        `> **PromptRev:** Unknown template \`${preSelectedKey}\`. Use \`@rev /template\` to browse available templates.`
+      );
+      return;
+    }
+  } else {
+    selectedTemplate = await pickTemplate(mergedTemplates, token);
+    if (!selectedTemplate) return; // user cancelled
+  }
+
+  // ── Step 2: offer editor selection as variable value ─────────────────────
+  const editorSelection = getEditorSelection();
+
+  // ── Step 3: collect variable values ──────────────────────────────────────
+  const variableValues = await collectVariables(
+    selectedTemplate,
+    editorSelection,
+    token
+  );
+  if (variableValues === undefined) return; // user cancelled
+
+  // ── Step 4: fill the template ─────────────────────────────────────────────
+  let filledPrompt: string;
+  try {
+    filledPrompt = resolveTemplate(selectedTemplate.key, variableValues, userTemplates);
+  } catch (err) {
+    if (err instanceof TemplateVariableError) {
+      stream.markdown(
+        `> **PromptRev:** Missing required variables: \`${err.missingVariables.join('`, `')}\`.`
+      );
+    }
+    return;
+  }
+
+  // ── Step 5: offer suggested modifier ─────────────────────────────────────
+  let chosenModifier = 'default';
+  if (selectedTemplate.suggestedModifier && selectedTemplate.suggestedModifier !== 'default') {
+    const modKey = selectedTemplate.suggestedModifier;
+    const modDef = BUILT_IN_MODIFIERS[modKey];
+    const label = modDef?.label ?? modKey;
+    const desc = modDef?.description ?? '';
+    const choice = await vscode.window.showInformationMessage(
+      `Apply :${label} modifier? ${desc}`,
+      `Yes, apply :${label}`,
+      'No, use default'
+    );
+    if (choice === undefined) return; // cancelled
+    if (choice.startsWith('Yes')) chosenModifier = modKey;
+  }
+
+  // ── Step 6: enhance ───────────────────────────────────────────────────────
+  const domainContext = projectConfig.getMergedDomainContext();
+  const model = await selectModel();
+  const adapter = model
+    ? new VSCodeModelAdapter(model, token)
+    : new RuleBasedAdapter();
+
+  const controller = new AbortController();
+  const cancelListener = token.onCancellationRequested(() => controller.abort());
+
+  stream.progress('Revising template prompt...');
+
+  try {
+    const result = await enhance({
+      rawPrompt: filledPrompt,
+      modifier: chosenModifier,
+      domainContext,
+      modelAdapter: adapter,
+      userModifiers: projectConfig.getMergedModifiers(),
+      signal: controller.signal,
+    });
+
+    getHistoryManager().add({
+      original: result.original,
+      revised: result.revised,
+      modifier: result.modifier as string,
+      accepted: false,
+    });
+    historyPanel.refresh();
+
+    renderTemplateResult(stream, result, selectedTemplate.name);
+  } catch (err) {
+    if (err instanceof Error && err.name === 'AbortError') return;
+    stream.markdown(
+      `> **PromptRev error:** ${err instanceof Error ? err.message : 'Unknown error'}`
+    );
+  } finally {
+    cancelListener.dispose();
+  }
+}
+
+/**
+ * Standalone command handler — opens the picker without a chat stream.
+ * Used by the promptrev.openTemplatePicker command (Cmd+Shift+T).
+ */
+export async function openTemplatePickerCommand(
+  historyPanel: HistoryPanelProvider,
+  projectConfig: ProjectConfigProvider
+): Promise<void> {
+  const mergedTemplates = projectConfig.getMergedTemplates();
+  const userTemplates = projectConfig.getMergedRawTemplates();
+
+  const tokenSource = new vscode.CancellationTokenSource();
+  const selectedTemplate = await pickTemplate(mergedTemplates, tokenSource.token);
+  if (!selectedTemplate) {
+    tokenSource.dispose();
+    return;
+  }
+
+  const editorSelection = getEditorSelection();
+  const variableValues = await collectVariables(selectedTemplate, editorSelection, tokenSource.token);
+  if (variableValues === undefined) {
+    tokenSource.dispose();
+    return;
+  }
+
+  let filledPrompt: string;
+  try {
+    filledPrompt = resolveTemplate(selectedTemplate.key, variableValues, userTemplates);
+  } catch (err) {
+    if (err instanceof TemplateVariableError) {
+      vscode.window.showWarningMessage(
+        `PromptRev: Missing required variables: ${err.missingVariables.join(', ')}`
+      );
+    }
+    tokenSource.dispose();
+    return;
+  }
+
+  // Offer suggested modifier
+  let chosenModifier = 'default';
+  if (selectedTemplate.suggestedModifier && selectedTemplate.suggestedModifier !== 'default') {
+    const modKey = selectedTemplate.suggestedModifier;
+    const modDef = BUILT_IN_MODIFIERS[modKey];
+    const label = modDef?.label ?? modKey;
+    const desc = modDef?.description ?? '';
+    const choice = await vscode.window.showInformationMessage(
+      `Apply :${label} modifier? ${desc}`,
+      `Yes, apply :${label}`,
+      'No, use default'
+    );
+    if (choice === undefined) {
+      tokenSource.dispose();
+      return;
+    }
+    if (choice.startsWith('Yes')) chosenModifier = modKey;
+  }
+
+  const domainContext = projectConfig.getMergedDomainContext();
+  const model = await selectModel();
+  const adapter = model
+    ? new VSCodeModelAdapter(model, tokenSource.token)
+    : new RuleBasedAdapter();
+
+  try {
+    const result = await enhance({
+      rawPrompt: filledPrompt,
+      modifier: chosenModifier,
+      domainContext,
+      modelAdapter: adapter,
+      userModifiers: projectConfig.getMergedModifiers(),
+    });
+
+    getHistoryManager().add({
+      original: result.original,
+      revised: result.revised,
+      modifier: result.modifier as string,
+      accepted: false,
+    });
+    historyPanel.refresh();
+
+    // Copy to clipboard and offer to open in chat
+    await vscode.env.clipboard.writeText(result.revised);
+    const action = await vscode.window.showInformationMessage(
+      `PromptRev: Template "${selectedTemplate.name}" filled and enhanced — copied to clipboard.`,
+      'Open in Chat',
+      'Dismiss'
+    );
+    if (action === 'Open in Chat') {
+      try {
+        await vscode.commands.executeCommand('workbench.action.chat.open', {
+          query: result.revised,
+          isPartialQuery: true,
+        });
+      } catch {
+        // Chat not available — clipboard copy was already done above
+      }
+    }
+  } catch (err) {
+    vscode.window.showErrorMessage(
+      `PromptRev: Template enhancement failed — ${err instanceof Error ? err.message : 'Unknown error'}`
+    );
+  } finally {
+    tokenSource.dispose();
+  }
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+async function pickTemplate(
+  mergedTemplates: MergedTemplate[],
+  _token: vscode.CancellationToken
+): Promise<PromptTemplate | undefined> {
+  // Group by source for separators
+  const groups: Record<string, MergedTemplate[]> = { 'built-in': [], user: [], team: [] };
+  for (const m of mergedTemplates) {
+    groups[m.source].push(m);
+  }
+
+  const items: (TemplateQuickPickItem | vscode.QuickPickItem)[] = [];
+
+  for (const source of ['built-in', 'user', 'team'] as const) {
+    const group = groups[source];
+    if (group.length === 0) continue;
+
+    items.push({ label: SOURCE_LABEL[source], kind: vscode.QuickPickItemKind.Separator });
+
+    for (const m of group) {
+      items.push({
+        label: `${SOURCE_ICON[source]} ${m.template.name}`,
+        description: m.template.description,
+        detail: m.template.tags.length > 0 ? m.template.tags.join(', ') : undefined,
+        templateKey: m.template.key,
+      } as TemplateQuickPickItem);
+    }
+  }
+
+  const picked = await vscode.window.showQuickPick(items as TemplateQuickPickItem[], {
+    title: 'PromptRev: Browse Templates',
+    placeHolder: 'Select a template to fill',
+    matchOnDescription: true,
+    matchOnDetail: true,
+  });
+
+  if (!picked || !('templateKey' in picked)) return undefined;
+
+  return mergedTemplates.find((m) => m.template.key === picked.templateKey)?.template;
+}
+
+async function collectVariables(
+  template: PromptTemplate,
+  editorSelection: string | undefined,
+  token: vscode.CancellationToken
+): Promise<Record<string, string> | undefined> {
+  const values: Record<string, string> = {};
+  const total = template.variables.length;
+
+  for (let i = 0; i < total; i++) {
+    if (token.isCancellationRequested) return undefined;
+
+    const variable = template.variables[i];
+
+    // Offer editor selection for variables likely to contain code/context
+    if (editorSelection && isContextVariable(variable.name) && !(variable.name in values)) {
+      const use = await vscode.window.showInformationMessage(
+        `PromptRev: Use editor selection as "${variable.description}"?`,
+        'Yes',
+        'No, I\'ll type it'
+      );
+      if (use === undefined) return undefined; // cancelled
+      if (use === 'Yes') {
+        values[variable.name] = editorSelection;
+        continue;
+      }
+    }
+
+    const inputBox = vscode.window.createInputBox();
+    inputBox.title = `${template.name} (${i + 1}/${total})`;
+    inputBox.prompt = variable.description;
+    inputBox.placeholder = variable.placeholder;
+    inputBox.ignoreFocusOut = true;
+
+    if (!variable.required) {
+      inputBox.buttons = [
+        { iconPath: new vscode.ThemeIcon('debug-step-over'), tooltip: 'Skip (optional)' },
+      ];
+    }
+
+    const value = await new Promise<string | undefined>((resolve) => {
+      let accepted = false;
+
+      inputBox.onDidAccept(() => {
+        accepted = true;
+        resolve(inputBox.value);
+        inputBox.dispose();
+      });
+
+      inputBox.onDidTriggerButton(() => {
+        // Skip button (only shown for optional variables)
+        accepted = true;
+        resolve('');
+        inputBox.dispose();
+      });
+
+      inputBox.onDidHide(() => {
+        if (!accepted) resolve(undefined);
+        inputBox.dispose();
+      });
+
+      token.onCancellationRequested(() => {
+        resolve(undefined);
+        inputBox.dispose();
+      });
+
+      inputBox.show();
+    });
+
+    if (value === undefined) return undefined; // user cancelled
+
+    // Required fields: keep prompting if blank
+    if (variable.required && !value.trim()) {
+      vscode.window.showWarningMessage(
+        `PromptRev: "${variable.description}" is required.`
+      );
+      i--; // retry this variable
+      continue;
+    }
+
+    values[variable.name] = value;
+  }
+
+  return values;
+}
+
+function getEditorSelection(): string | undefined {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor || editor.selection.isEmpty) return undefined;
+  const text = editor.document.getText(editor.selection).trim();
+  return text || undefined;
+}
+
+/** Variables that are good candidates for injecting editor selection */
+function isContextVariable(name: string): boolean {
+  return ['context', 'code', 'file_or_module', 'target'].includes(name);
+}
+
+function renderTemplateResult(
+  stream: vscode.ChatResponseStream,
+  result: EnhancerOutput,
+  templateName: string
+): void {
+  addPendingResult(result);
+
+  const header = result.signal
+    ? `✨ **${templateName}** — ${result.signal}`
+    : `✨ **${templateName}** template filled and enhanced:`;
+
+  stream.markdown(`${header}\n\n`);
+  stream.markdown(`\`\`\`\n${result.revised}\n\`\`\``);
+  stream.markdown('\n\n**Changes:**\n\n');
+  stream.markdown(formatDiffMarkdown(result.original, result.revised));
+  stream.markdown('\n\n');
+
+  stream.button({
+    command: 'promptrev.accept',
+    title: '$(check) Send Improved',
+    arguments: [result.timestamp],
+  });
+  stream.button({
+    command: 'promptrev.sendOriginal',
+    title: '$(arrow-right) Send Original',
+    arguments: [result.timestamp],
+  });
+  stream.button({
+    command: 'promptrev.editFirst',
+    title: '$(edit) Edit',
+    arguments: [result.timestamp],
+  });
+}


### PR DESCRIPTION
## Summary

- **Core**: adds `PromptTemplate` data model, 8 built-in templates (bug-fix, code-review, architecture, refactor, test-generation, explain-code, pr-description, incident-postmortem), `resolveTemplate()` with required-variable enforcement and user-override support
- **VS Code**: template picker (`@rev /template` + `Cmd+Shift+T`) with grouped Quick Pick, per-variable `createInputBox` input flow, suggested modifier offer, and editor selection injection for context fields
- **Config**: three-layer merge (built-ins → `settings.json` → `.promptrev.json`) so user/team templates appear alongside built-ins in the picker
- **CI/CD**: publish workflow now triggers on push to `main` when any `package.json` changes, eliminating manual publish trigger after version bumps

## Closes

Closes #37, #38, #39

## Test plan

- [ ] `pnpm --filter @promptrev/core test` — all 50 tests pass (13 new template tests)
- [ ] F5 in VS Code → type `@rev /template` → Quick Pick shows 8 built-in templates grouped
- [ ] Select `bug-fix` → variable input flow steps through 6 fields → fills template
- [ ] Suggested modifier offer appears (`:default` for bug-fix)
- [ ] `@rev /bug-fix` skips Quick Pick and goes directly to variable input
- [ ] `Cmd+Shift+T` opens standalone picker → result copied to clipboard
- [ ] Add `templates` key to `.promptrev.json` → team template appears in picker under "Team" section
- [ ] Add `promptrev.templates` to `settings.json` → user template appears under "Your templates"
- [ ] Merge PR → verify publish workflow fires automatically (via push trigger on package.json change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)