### PR TITLE
refactor: rename /fast → /rb and simplify enhanced prompt response

### DIFF
--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -6,16 +6,16 @@ import { resolve } from 'path';
 const BIN = resolve(__dirname, '../../dist/bin/rev.js');
 
 describe('rev CLI', () => {
-  it('--mod fast enhances prompt without API call', async () => {
-    const { stdout, exitCode } = await execa('node', [BIN, '--mod', 'fast', 'fix the bug in my app'], {
+  it('--mod rb enhances prompt without API call', async () => {
+    const { stdout, exitCode } = await execa('node', [BIN, '--mod', 'rb', 'fix the bug in my app'], {
       env: { ...process.env, PROMPTREV_API_KEY: undefined, ANTHROPIC_API_KEY: undefined },
     });
     expect(exitCode).toBe(0);
     expect(stdout.length).toBeGreaterThan(0);
   });
 
-  it('--mod fast reads from stdin', async () => {
-    const { stdout, exitCode } = await execa('node', [BIN, '--mod', 'fast'], {
+  it('--mod rb reads from stdin', async () => {
+    const { stdout, exitCode } = await execa('node', [BIN, '--mod', 'rb'], {
       input: 'fix the authentication bug',
       env: { ...process.env, PROMPTREV_API_KEY: undefined, ANTHROPIC_API_KEY: undefined },
     });
@@ -23,10 +23,10 @@ describe('rev CLI', () => {
     expect(stdout.length).toBeGreaterThan(0);
   });
 
-  it('--json outputs valid JSON with expected shape for --mod fast', async () => {
+  it('--json outputs valid JSON with expected shape for --mod rb', async () => {
     const { stdout, exitCode } = await execa(
       'node',
-      [BIN, '--mod', 'fast', '--json', 'fix the bug in my app'],
+      [BIN, '--mod', 'rb', '--json', 'fix the bug in my app'],
       {
         env: { ...process.env, PROMPTREV_API_KEY: undefined, ANTHROPIC_API_KEY: undefined },
       }
@@ -45,7 +45,7 @@ describe('rev CLI', () => {
     expect(exitCode).toBe(0);
     expect(stdout).toContain('Modifier');
     expect(stdout).toContain('default');
-    expect(stdout).toContain('fast');
+    expect(stdout).toContain('rb');
     expect(stdout).toContain('deep');
   });
 
@@ -63,7 +63,7 @@ describe('rev CLI', () => {
   });
 
   it('exits 1 with error when no prompt provided', async () => {
-    const { stderr, exitCode } = await execa('node', [BIN, '--mod', 'fast'], {
+    const { stderr, exitCode } = await execa('node', [BIN, '--mod', 'rb'], {
       reject: false,
       // No input, no arg, isTTY will be false but stdin will end immediately
       input: '',

--- a/packages/cli/src/bin/rev.ts
+++ b/packages/cli/src/bin/rev.ts
@@ -11,7 +11,7 @@ program
   .description('Enhance your AI prompts before sending them')
   .version('0.1.0')
   .argument('[prompt]', 'Prompt text to enhance (or pipe via stdin)')
-  .option('-m, --mod <modifier>', 'Modifier to apply (default, fast, deep, architect, critic, spell, spec)', 'default')
+  .option('-m, --mod <modifier>', 'Modifier to apply (default, rb, deep, architect, critic, spell, spec)', 'default')
   .option('-f, --file <path>', 'Read prompt from a file')
   .option('--json', 'Output full result as JSON')
   .option('--model <model>', 'Override the model (e.g. claude-opus-4-6)')
@@ -32,7 +32,7 @@ program
     }
 
     const modifier = options.mod as string;
-    const isFast = modifier === 'fast';
+    const isFast = modifier === 'rb';
 
     // :fast uses rule-based adapter — no API key required
     let adapter;
@@ -44,7 +44,7 @@ program
         console.error(
           'Error: No API key found.\n' +
             'Set PROMPTREV_API_KEY or ANTHROPIC_API_KEY environment variable.\n' +
-            'Or use --mod fast for rule-based enhancement with no API key.'
+            'Or use --mod rb for rule-based enhancement with no API key.'
         );
         process.exit(1);
       }

--- a/packages/core/src/__tests__/enhancer.test.ts
+++ b/packages/core/src/__tests__/enhancer.test.ts
@@ -32,11 +32,11 @@ describe('enhance', () => {
     expect(result.skipped).toBe(false);
   });
 
-  it('does NOT call modelAdapter for :fast modifier', async () => {
+  it('does NOT call modelAdapter for :rb modifier', async () => {
     const adapter = makeMockAdapter('Should not be called');
     const result = await enhance({
       rawPrompt: 'fix the bug in my app',
-      modifier: 'fast',
+      modifier: 'rb',
       modelAdapter: adapter,
     });
     expect(adapter.complete).not.toHaveBeenCalled();

--- a/packages/core/src/__tests__/history.test.ts
+++ b/packages/core/src/__tests__/history.test.ts
@@ -17,7 +17,7 @@ describe('HistoryManager', () => {
 
   it('entries are returned newest-first', () => {
     manager.add({ original: 'first', revised: 'First.', modifier: 'default', accepted: true });
-    manager.add({ original: 'second', revised: 'Second.', modifier: 'fast', accepted: true });
+    manager.add({ original: 'second', revised: 'Second.', modifier: 'rb', accepted: true });
     const entries = manager.getAll();
     expect(entries[0].original).toBe('second');
     expect(entries[1].original).toBe('first');

--- a/packages/core/src/__tests__/modifiers.test.ts
+++ b/packages/core/src/__tests__/modifiers.test.ts
@@ -9,8 +9,8 @@ describe('resolveModifier', () => {
     expect(mod.acceptMode).toBe('diff');
   });
 
-  it('fast modifier is rule-based (useLLM: false)', () => {
-    const mod = resolveModifier('fast');
+  it('rb modifier is rule-based (useLLM: false)', () => {
+    const mod = resolveModifier('rb');
     expect(mod.useLLM).toBe(false);
     expect(mod.autoSend).toBe(true);
     expect(mod.acceptMode).toBe('auto');

--- a/packages/core/src/enhancer.ts
+++ b/packages/core/src/enhancer.ts
@@ -86,7 +86,7 @@ export async function enhance(input: EnhancerInput): Promise<EnhancerOutput> {
   let qualitySignal: string | undefined;
 
   if (!modifierDef.useLLM) {
-    // :fast mode — rule-based only, no LLM call
+    // :rb mode — rule-based only, no LLM call
     revised = ruleBasedEnhance(rawPrompt);
   } else {
     const systemPrompt = interpolateSystemPrompt(modifierDef.systemPrompt, domainContext);

--- a/packages/core/src/model-adapter.ts
+++ b/packages/core/src/model-adapter.ts
@@ -12,7 +12,7 @@ export interface ModelAdapter {
 
 /**
  * Rule-based fallback adapter — no LLM call.
- * Used by :fast mode and when no model is available.
+ * Used by :rb mode and when no model is available.
  */
 export class RuleBasedAdapter implements ModelAdapter {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/core/src/modifiers.ts
+++ b/packages/core/src/modifiers.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 export const ModifierKeySchema = z.enum([
   'default',
-  'fast',
+  'rb',
   'deep',
   'architect',
   'critic',
@@ -18,7 +18,7 @@ export interface ModifierDefinition {
   systemPrompt: string;
   acceptMode: 'diff' | 'auto';
   autoSend: boolean;
-  /** false = rule-based only, no LLM call (used by :fast) */
+  /** false = rule-based only, no LLM call (used by :rb) */
   useLLM: boolean;
 }
 
@@ -105,10 +105,10 @@ export const BUILT_IN_MODIFIERS: Record<string, ModifierDefinition> = {
     autoSend: false,
     useLLM: true,
   },
-  fast: {
-    key: 'fast',
-    label: 'Fast',
-    description: 'Quick sharpen — rule-based, zero latency, auto-accept',
+  rb: {
+    key: 'rb',
+    label: 'Rule-Based',
+    description: 'Rule-based enhancement — no model required, auto-accept',
     systemPrompt: '', // rule-based: no LLM system prompt
     acceptMode: 'auto',
     autoSend: true,

--- a/packages/core/src/rule-based.ts
+++ b/packages/core/src/rule-based.ts
@@ -1,5 +1,5 @@
 /**
- * Rule-based prompt enhancement for :fast mode.
+ * Rule-based prompt enhancement for :rb mode.
  * No LLM call — deterministic, zero latency.
  */
 
@@ -117,7 +117,7 @@ function ensureImperative(text: string): string {
 
 /**
  * Apply all rule-based enhancements in sequence.
- * Used by :fast mode — no LLM call required.
+ * Used by :rb mode — no LLM call required.
  */
 export function ruleBasedEnhance(raw: string): string {
   let result = raw.trim();

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -128,4 +128,4 @@ Commit a `.promptrev.json` at the repo root to share modifiers and templates acr
 - VS Code `1.85.0` or later
 - GitHub Copilot or another VS Code language model extension (recommended)
 
-If no model is available, `:fast` mode still works via rule-based enhancement — no model required.
+If no model is available, `:rb` mode still works via rule-based enhancement — no model required.

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -1,90 +1,87 @@
-# PromptRev — VS Code Extension
+# PromptRev
 
-> Instantly enhance your AI prompts with `@rev` — before you send them.
+**Enhance your AI prompts before you send them — directly in VS Code Chat.**
 
-PromptRev makes every developer a prompt engineer without them needing to think about it. Type `@rev your rough prompt` in any VS Code Chat panel and get a polished, context-aware version back in under a second — with a diff showing exactly what changed.
+Type `@rev your rough prompt` and get a polished, context-aware version back with a diff showing exactly what changed. No API key required. No background process. Works with whatever model you already have.
 
-## How it works
+---
 
-```mermaid
-sequenceDiagram
-    participant Dev as Developer
-    participant Chat as VS Code Chat
-    participant Rev as @rev participant
-    participant LM as vscode.lm (Copilot/Claude)
+## Getting started
 
-    Dev->>Chat: @rev fix the bug in my auth module
-    Chat->>Rev: handler(request)
-    Rev->>LM: enhance with default modifier
-    LM-->>Rev: polished prompt
-    Rev-->>Chat: diff preview + revised prompt
-    Dev->>Chat: copies revised prompt → sends to AI
-```
-
-No separate API key required. PromptRev reuses whatever model you already have active (GitHub Copilot, Claude, etc.) via VS Code's `vscode.lm` API. If no model is available, it falls back to rule-based enhancement automatically.
-
-## Features
-
-- **`@rev` Chat Participant** — first-class VS Code Chat integration with autocomplete
-- **6 built-in modifiers** — `:fast`, `:deep`, `:architect`, `:critic`, `:spell`, `:spec`
-- **`Cmd+Shift+E`** — enhance selected text in any editor without opening chat
-- **Diff preview** — see exactly what changed before accepting
-- **Prompt history panel** — restore, review, and export past enhancements
-- **Zero setup** — no API key, no background process, works with your existing model
-- **Custom modifiers** — define team-specific enhancement rules in `.promptrev.json`
-
-## Usage
-
-### `@rev` in VS Code Chat
-
-Type `@rev` followed by your prompt in any VS Code Chat panel:
+1. Install the extension
+2. Open VS Code Chat (`Ctrl+Alt+I` / `Cmd+Alt+I`)
+3. Type `@rev` followed by your prompt
 
 ```
 @rev fix the bug in my auth module
 ```
 
-PromptRev intercepts the message, enhances it, and returns a diff preview with the revised prompt ready to copy.
+PromptRev enhances the prompt, shows you what changed, and gives you three options: **Send Improved**, **Edit**, or **Send Original**.
 
-### Modifiers
+---
 
-Append a modifier with `/` in the chat command:
+## Modifiers
 
-| Command | Best for |
+Append a `/modifier` to control how your prompt is rewritten:
+
+| Command | What it does |
 |---|---|
-| `@rev` | Everyday prompts — clarity, structure, context |
-| `@rev /fast` | In-flow quick fixes — rule-based, zero latency, auto-accept |
-| `@rev /deep` | Complex tasks — chain-of-thought, edge cases, structure |
-| `@rev /architect` | System design — trade-offs, components, scalability |
-| `@rev /critic` | Code review — failure modes, security, assumptions |
-| `@rev /spell` | Grammar and spelling only — no restructuring |
-| `@rev /spec` | Convert a vague idea into a structured spec |
+| `@rev` | Clarity, structure, and missing context — everyday default |
+| `@rev /rb` | Rule-based enhancement — no model required, auto-accept |
+| `@rev /deep` | Chain-of-thought framing, edge cases, structured output |
+| `@rev /architect` | System design framing — trade-offs, components, scalability |
+| `@rev /critic` | Adversarial review — failure modes, security, assumptions |
+| `@rev /spell` | Grammar and spelling only, no restructuring |
+| `@rev /spec` | Converts a vague idea into a structured spec |
 
-### Keybinding — enhance selected text
+---
 
-Select any text in the editor and press `Cmd+Shift+E` (Mac) or `Ctrl+Shift+E` (Windows/Linux):
+## Prompt templates
 
-1. Select your rough prompt text in any file
-2. Press the keybinding
-3. Choose **Replace Selection**, **Copy to Clipboard**, or **Dismiss**
+Browse and fill reusable prompt structures with `@rev /template` or `Cmd+Shift+T`:
 
-Works in `.md` files, scratch files, code comments — anywhere you draft prompts.
+| Template | Best for |
+|---|---|
+| `/bug-fix` | Root cause + fix + regression test |
+| `/code-review` | Structured review with severity ratings |
+| `/architecture` | System design with constraints and trade-offs |
+| `/refactor` | Targeted refactor with goals and risk notes |
+| `/test-generation` | Tests with coverage goals and edge cases |
+| `/explain-code` | Code explanation at a specified audience level |
+| `/pr-description` | PR title, summary, and test plan |
+| `/incident-postmortem` | Timeline, root cause, and action items |
+
+Each template walks you through filling in variables step-by-step. If you have text selected in the editor, PromptRev will offer to use it as context automatically.
+
+---
+
+## Keybinding — enhance selected text
+
+Select any text and press `Cmd+Shift+E` (Mac) / `Ctrl+Shift+E` (Windows/Linux) to enhance it without opening chat. Works in `.md` files, scratch pads, code comments — anywhere you draft prompts.
+
+---
 
 ## Configuration
 
-All settings live in VS Code `settings.json` under the `promptrev.*` namespace:
-
 ```json
 {
-  "promptrev.acceptMode": "diff",
-  "promptrev.autoSend": false,
-  "promptrev.keepHistory": true,
-  "promptrev.maxHistory": 100,
   "promptrev.domainContext": "React + TypeScript, Node.js, PostgreSQL",
+  "promptrev.maxHistory": 100,
   "promptrev.modifiers": {
-    "fast": { "autoSend": true },
     "backend": {
-      "systemPrompt": "Rewrite for a TypeScript/Express backend. Always include error handling, input validation, and Prisma/PostgreSQL context.",
+      "systemPrompt": "Rewrite for a Node.js + Express + Prisma backend. Include TypeScript, JWT auth, error handling, and input validation.",
       "acceptMode": "diff"
+    }
+  },
+  "promptrev.templates": {
+    "my-api-endpoint": {
+      "name": "API Endpoint Design",
+      "template": "Design a {{method}} endpoint at {{path}} for {{purpose}}.",
+      "variables": [
+        { "name": "method", "placeholder": "POST", "required": true },
+        { "name": "path", "placeholder": "/api/users", "required": true },
+        { "name": "purpose", "placeholder": "creating a user", "required": true }
+      ]
     }
   }
 }
@@ -92,62 +89,43 @@ All settings live in VS Code `settings.json` under the `promptrev.*` namespace:
 
 | Setting | Default | Description |
 |---|---|---|
-| `promptrev.acceptMode` | `"diff"` | `"diff"` shows a preview, `"auto"` accepts immediately |
-| `promptrev.autoSend` | `false` | Auto-send accepted prompt to the AI |
-| `promptrev.keepHistory` | `true` | Track enhancement history |
-| `promptrev.maxHistory` | `100` | Max history entries (1–500) |
 | `promptrev.domainContext` | `""` | Tech stack injected into every enhancement |
+| `promptrev.maxHistory` | `100` | Max history entries kept (1–500) |
 | `promptrev.modifiers` | `{}` | Custom or overridden modifier definitions |
+| `promptrev.templates` | `{}` | Custom template definitions |
 
-### Project-level config
+### Team config
 
-Create a `.promptrev.json` at the workspace root to share modifier definitions with your team:
+Commit a `.promptrev.json` at the repo root to share modifiers and templates across your team:
 
 ```json
 {
+  "domainContext": "React + TypeScript, Node.js, PostgreSQL",
   "modifiers": {
     "backend": {
-      "systemPrompt": "Rewrite this prompt for a Node.js + Express + PostgreSQL + Prisma backend. Include TypeScript, JWT auth, error handling, and input validation in every response.",
+      "systemPrompt": "Rewrite for our Node.js + Prisma stack.",
       "acceptMode": "diff"
-    },
-    "frontend": {
-      "systemPrompt": "Rewrite this prompt for a React + TypeScript frontend. Include accessibility, component structure, and state management considerations.",
-      "acceptMode": "diff"
+    }
+  },
+  "templates": {
+    "incident-report": {
+      "name": "Incident Report",
+      "template": "Write a postmortem for {{service}} — duration: {{duration}}, impact: {{impact}}.",
+      "variables": [
+        { "name": "service", "placeholder": "payments-api", "required": true },
+        { "name": "duration", "placeholder": "47 minutes", "required": true },
+        { "name": "impact", "placeholder": "checkout unavailable for EU users", "required": true }
+      ]
     }
   }
 }
 ```
 
-## Model fallback chain
-
-```mermaid
-flowchart LR
-    A[Enhancement request] --> B{vscode.lm available?}
-    B -->|yes| C[Use active Copilot/Claude model]
-    B -->|no| D{API key configured?}
-    D -->|yes| E[Use configured API key]
-    D -->|no| F{modifier = :fast?}
-    F -->|yes| G[Rule-based enhancement]
-    F -->|no| H[Show: No model available]
-```
+---
 
 ## Requirements
 
-- VS Code `^1.85.0`
-- GitHub Copilot (recommended) or another VS Code language model extension
+- VS Code `1.85.0` or later
+- GitHub Copilot or another VS Code language model extension (recommended)
 
-## Development
-
-```bash
-# From monorepo root
-pnpm install
-pnpm build:core
-
-# Build the extension
-pnpm --filter @promptrev/vscode build
-
-# Watch mode
-pnpm --filter @promptrev/vscode watch
-
-# Press F5 in VS Code to launch Extension Development Host
-```
+If no model is available, `:fast` mode still works via rule-based enhancement — no model required.

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -32,8 +32,8 @@
         "isSticky": false,
         "commands": [
           {
-            "name": "fast",
-            "description": "Quick sharpen — rule-based, zero latency, auto-accept"
+            "name": "rb",
+            "description": "Rule-based enhancement — no model required, auto-accept"
           },
           {
             "name": "deep",

--- a/packages/vscode/src/model-selector.ts
+++ b/packages/vscode/src/model-selector.ts
@@ -21,7 +21,7 @@ export async function selectModel(): Promise<vscode.LanguageModelChat | null> {
  * Returns true if the caller should abort (no model + modifier needs LLM).
  */
 export async function handleNoModel(modifier: string): Promise<boolean> {
-  if (modifier === 'fast') return false; // fast is rule-based, no model needed
+  if (modifier === 'rb') return false; // rb is rule-based, no model needed
 
   const action = await vscode.window.showWarningMessage(
     'PromptRev: No language model available. Activate GitHub Copilot or configure an API key.',

--- a/packages/vscode/src/participant.ts
+++ b/packages/vscode/src/participant.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { enhance, RuleBasedAdapter, resolveModifier, formatDiffMarkdown, BUILT_IN_TEMPLATES } from '@promptrev/core';
+import { enhance, RuleBasedAdapter, resolveModifier, BUILT_IN_TEMPLATES } from '@promptrev/core';
 import type { EnhancerOutput } from '@promptrev/core';
 import { VSCodeModelAdapter } from './vscode-model-adapter';
 import { parseModifierFromCommand } from './utils';
@@ -120,7 +120,7 @@ async function handler(
     });
     historyPanel.refresh();
 
-    // :fast and any modifier with acceptMode:'auto' — skip diff, show result directly (#13)
+    // :rb and any modifier with acceptMode:'auto' — skip diff, show result directly (#13)
     if (modifierDef.acceptMode === 'auto') {
       stream.markdown(`**Enhanced prompt:**\n\n\`\`\`\n${result.revised}\n\`\`\``);
       addPendingResult(result);
@@ -152,12 +152,7 @@ function renderResult(
     ? `✨ ${result.signal}`
     : '✨ **Prompt improved** — revised prompt ready to send:';
   stream.markdown(`${signalLine}\n\n`);
-  stream.markdown(`\`\`\`\n${result.revised}\n\`\`\``);
-
-  // Diff below as secondary context
-  stream.markdown('\n\n**Changes:**\n\n');
-  stream.markdown(formatDiffMarkdown(result.original, result.revised));
-  stream.markdown('\n\n');
+  stream.markdown(`\`\`\`\n${result.revised}\n\`\`\`\n\n`);
 
   // Three buttons — clear hierarchy, no Dismiss (closing chat is implicit dismissal)
   stream.button({

--- a/packages/vscode/src/template-picker.ts
+++ b/packages/vscode/src/template-picker.ts
@@ -11,7 +11,6 @@ import { VSCodeModelAdapter } from './vscode-model-adapter';
 import { selectModel } from './model-selector';
 import { addPendingResult } from './commands';
 import { getHistoryManager } from './history-manager';
-import { formatDiffMarkdown } from '@promptrev/core';
 import type { HistoryPanelProvider } from './history-panel';
 import type { ProjectConfigProvider, MergedTemplate } from './project-config';
 
@@ -402,10 +401,7 @@ function renderTemplateResult(
     : `✨ **${templateName}** template filled and enhanced:`;
 
   stream.markdown(`${header}\n\n`);
-  stream.markdown(`\`\`\`\n${result.revised}\n\`\`\``);
-  stream.markdown('\n\n**Changes:**\n\n');
-  stream.markdown(formatDiffMarkdown(result.original, result.revised));
-  stream.markdown('\n\n');
+  stream.markdown(`\`\`\`\n${result.revised}\n\`\`\`\n\n`);
 
   stream.button({
     command: 'promptrev.accept',

--- a/packages/vscode/src/utils.ts
+++ b/packages/vscode/src/utils.ts
@@ -1,6 +1,6 @@
 /**
  * Extracts the modifier from the chat command field.
- * @rev/fast → 'fast', @rev/deep → 'deep', undefined → 'default'
+ * @rev/rb → 'rb', @rev/deep → 'deep', undefined → 'default'
  */
 export function parseModifierFromCommand(command?: string): string {
   if (!command) return 'default';


### PR DESCRIPTION
## Summary

- **Rename `/fast` → `/rb`** (rule-based) across core, CLI, VS Code extension, tests, and README. The old name described a side-effect (speed); `/rb` names the actual capability — no model required, runs offline. Removes the redundant "zero latency" copy.
- **Remove diff view** from the enhanced prompt response (both modifier flow and template flow). The quality signal already tells the user what changed in one sentence. The diff added noise for longer prompts without helping the accept/reject decision. New layout: **signal → improved prompt → action buttons**.
- **Filed #50** — security issue tracking supply-chain attack risk on prompt content (separate, not part of this PR).

## Test plan

- [ ] `@rev fix my auth bug` → response shows signal + improved prompt + 3 buttons, no diff section
- [ ] `@rev /rb fix typos here` → auto-accepts immediately, no model call
- [ ] `@rev /template bug-fix` → template flow shows signal + filled prompt, no diff
- [ ] CLI: `rev --mod rb "fix the bug"` → still works, no API key required
- [ ] `pnpm --filter @promptrev/core test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)