### PR TITLE
chore: bump all packages to v0.7.1

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,8 +1,15 @@
 {
   "name": "promptrev",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Enhance your AI prompts from the terminal",
-  "keywords": ["prompt", "ai", "cli", "enhancement", "anthropic", "claude"],
+  "keywords": [
+    "prompt",
+    "ai",
+    "cli",
+    "enhancement",
+    "anthropic",
+    "claude"
+  ],
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -22,7 +29,9 @@
       "require": "./dist/index.cjs"
     }
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsup",
     "watch": "tsup --watch",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@promptrev/core",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "PromptRev core enhancement engine — shared logic for VS Code extension and CLI",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "promptrev",
   "displayName": "PromptRev",
   "description": "Instantly enhance your AI prompts with @rev",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "publisher": "promptrev",
   "repository": {
     "type": "git",
@@ -18,9 +18,20 @@
     "color": "#4F46E5",
     "theme": "dark"
   },
-  "categories": ["AI", "Other"],
-  "keywords": ["prompt", "ai", "copilot", "enhancement", "chat"],
-  "activationEvents": ["onStartupFinished"],
+  "categories": [
+    "AI",
+    "Other"
+  ],
+  "keywords": [
+    "prompt",
+    "ai",
+    "copilot",
+    "enhancement",
+    "chat"
+  ],
+  "activationEvents": [
+    "onStartupFinished"
+  ],
   "main": "./dist/extension.js",
   "contributes": {
     "chatParticipants": [
@@ -142,7 +153,11 @@
       "properties": {
         "promptrev.acceptMode": {
           "type": "string",
-          "enum": ["diff", "auto", "preview"],
+          "enum": [
+            "diff",
+            "auto",
+            "preview"
+          ],
           "enumDescriptions": [
             "Show a diff preview before accepting",
             "Auto-accept the enhanced prompt",


### PR DESCRIPTION
Bumps `@promptrev/core`, `promptrev` (CLI), and the VS Code extension to `0.7.1`.

Includes changes from v0.7.0 → v0.7.1:
- Renamed `/fast` → `/rb` (rule-based)
- Removed diff view from enhanced prompt response
- Removed docs/ folder

Once merged, the scheduled publish workflow will automatically push to npm and the VS Code Marketplace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)