### PR TITLE
fix: unblock npm OIDC Trusted Publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -51,6 +50,8 @@ jobs:
             echo "promptrev@$LOCAL is already published — skipping."
           else
             echo "Publishing promptrev@$LOCAL..."
+            # Clear any stale auth token so npm uses OIDC Trusted Publishing
+            npm config delete //registry.npmjs.org/:_authToken 2>/dev/null || true
             cd packages/cli && npm publish --provenance --access public
             echo "✅ Published promptrev@$LOCAL to npm"
           fi


### PR DESCRIPTION
## Problem

The `publish-npm` job was failing with `404 Not Found` on `PUT https://registry.npmjs.org/promptrev`.

**Root cause:** `actions/setup-node` with `registry-url` writes an `.npmrc` that sets `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}`. Since we use OIDC Trusted Publishing (no `NPM_TOKEN` secret), `NODE_AUTH_TOKEN` is empty — npm sends a blank auth header and gets a 404 instead of falling through to the OIDC token exchange.

## Fix

- Remove `registry-url` from `setup-node` in the `publish-npm` job
- Explicitly clear any stale auth token before publishing so npm detects the GitHub Actions OIDC context and exchanges it for a short-lived publish token automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)