### PR TITLE
fix: npm OIDC auth + bump actions to Node 22

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -50,8 +51,9 @@ jobs:
             echo "promptrev@$LOCAL is already published — skipping."
           else
             echo "Publishing promptrev@$LOCAL..."
-            # Clear any stale auth token so npm uses OIDC Trusted Publishing
-            npm config delete //registry.npmjs.org/:_authToken 2>/dev/null || true
+            # Remove the NODE_AUTH_TOKEN placeholder written by setup-node so
+            # npm falls through to OIDC Trusted Publishing automatically
+            npm config delete //registry.npmjs.org/:_authToken
             cd packages/cli && npm publish --provenance --access public
             echo "✅ Published promptrev@$LOCAL to npm"
           fi
@@ -70,7 +72,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,7 +82,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 20
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
 
       # npm ≥11.5.1 is required for OIDC Trusted Publishing
       - name: Upgrade npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.5.1
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 20
           registry-url: 'https://registry.npmjs.org'
 
       # npm ≥11.5.1 is required for OIDC Trusted Publishing

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,10 @@ jobs:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'
 
+      # npm ≥11.5.1 is required for OIDC Trusted Publishing
+      - name: Upgrade npm
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -51,9 +55,6 @@ jobs:
             echo "promptrev@$LOCAL is already published — skipping."
           else
             echo "Publishing promptrev@$LOCAL..."
-            # Remove the NODE_AUTH_TOKEN placeholder written by setup-node so
-            # npm falls through to OIDC Trusted Publishing automatically
-            npm config delete //registry.npmjs.org/:_authToken
             cd packages/cli && npm publish --provenance --access public
             echo "✅ Published promptrev@$LOCAL to npm"
           fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,6 +43,15 @@ jobs:
       - name: Build CLI
         run: pnpm --filter './packages/cli' build
 
+      - name: Ensure no npm auth token (OIDC Trusted Publishing)
+        run: |
+          NPMRC="${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
+          if [ -f "$NPMRC" ]; then
+            echo "Removing any _authToken entries from $NPMRC"
+            sed -i.bak '/_authToken/d' "$NPMRC"
+            rm -f "$NPMRC.bak"
+          fi
+
       - name: Check version and publish
         run: |
           LOCAL=$(node -p "require('./packages/cli/package.json').version")


### PR DESCRIPTION
## Changes

**npm OIDC fix (attempt 3):**

| Attempt | Change | Result |
|---|---|---|
| 1 | Had `registry-url`, no auth token deletion | 404 — blank token sent |
| 2 | Removed `registry-url` entirely | ENEEDAUTH — no registry config at all |
| 3 (this PR) | Restore `registry-url`, delete `_authToken` before publish | npm sees registry but no token → falls through to OIDC exchange |

`setup-node` with `registry-url` writes `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` to `.npmrc`. Deleting that key after setup but before `npm publish` leaves the registry configured while removing the auth placeholder — npm then detects the GitHub Actions OIDC context and exchanges it for a short-lived token automatically.

**Node 22:**
Bumps `node-version` from `20` to `22` in both jobs to clear the deprecation warning about Node.js 20 actions being retired June 2026.

🤖 Generated with [Claude Code](https://claude.com/claude-code)